### PR TITLE
assets: remove redundant -v from deployment

### DIFF
--- a/bindata/assets/secondary-scheduler/deployment.yaml
+++ b/bindata/assets/secondary-scheduler/deployment.yaml
@@ -33,7 +33,6 @@ spec:
           args:
             - /bin/kube-scheduler
             - --config=/etc/kubernetes/config.yaml
-            - -v=2
           volumeMounts:
             - mountPath: "/etc/kubernetes"
               name: "etckubernetes"


### PR DESCRIPTION
The kube-scheduler-operator is already handling the verbosiness
setting if the `logLevel` value is given in the SecondaryScheduler
object, like in this snippet:

```yaml
apiVersion: operator.openshift.io/v1
kind: SecondaryScheduler
metadata:
  name: secondary-scheduler
  namespace: openshift-secondary-scheduler-operator
spec:
  managementState: Managed
  logLevel: Trace
  schedulerConfig: topo-aware-scheduler-config
  imageSpec: quay.io/openshift-kni/scheduler-plugin:latest
```

This means that the `-v` setting in the embedded deployment.yaml
is redundant, because another `-v` setting is always going to be
appended.

Signed-off-by: Francesco Romani <fromani@redhat.com>