### PR TITLE
bug 2057358: Fix the CRD name

### DIFF
--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ spec:
       description: SecondaryScheduler is the Schema for the secondaryschedulers API
       group: operator.openshift.io
       kind: SecondaryScheduler
-      name: Secondaryschedulers.operator.openshift.io
+      name: secondaryschedulers.operator.openshift.io
       version: v1
   description: |
       The Secondary Scheduler Operator provides the ability to a customized scheduler image developed using the scheduler plugin framework with customized configuration as a secondary scheduler in OpenShift.


### PR DESCRIPTION
The name needs to by identical as the CRD name itself: https://github.com/openshift/secondary-scheduler-operator/blob/master/manifests/secondary-scheduler-operator.crd.yaml#L4