### PR TITLE
bug 2058692: Expect the SecondarySchedulers CR to be named as 'cluster'

### DIFF
--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -11,7 +11,7 @@ import (
 )
 
 const OperatorNamespace = "openshift-secondary-scheduler-operator"
-const OperatorConfigName = "secondary-scheduler"
+const OperatorConfigName = "cluster"
 
 type SecondarySchedulerClient struct {
 	Ctx            context.Context


### PR DESCRIPTION
By default operator creates a CR called "cluster". E.g.

```
$ oc get kubescheduler
NAME      AGE
cluster   3h40m
$ oc get kubeapiserver
NAME      AGE
cluster   3h40m
$ oc get kubecontrollermanager
NAME      AGE
cluster   3h40m
```