### PR TITLE
Enable OpenShift Authentication for scheduler plugins

### DIFF
--- a/bindata/assets/secondary-scheduler/deployment.yaml
+++ b/bindata/assets/secondary-scheduler/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - name: "secondary-scheduler"
           image: ${IMAGE}
           env:
-          - name: EnableOpenShiftAuth
+          - name: ENABLE_OPENSHIFT_AUTH
             value: true
           resources:
             limits:

--- a/bindata/assets/secondary-scheduler/deployment.yaml
+++ b/bindata/assets/secondary-scheduler/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       containers:
         - name: "secondary-scheduler"
           image: ${IMAGE}
+          env:
+          - name: EnableOpenShiftAuth
+            value: true
           resources:
             limits:
               cpu: "100m"


### PR DESCRIPTION
This environment variable allows all scheduler plugins to enable OpenShift authentication to Prometheus metrics.
Trimaran plugins particularly used load-watcher libaries to fetch prometheus metrics, which in OpenShift would need a different authentication method than in k8s. It is supported here: https://github.com/paypal/load-watcher/pull/49