### PR TITLE
Dockerfile: bump golang version to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
 WORKDIR /go/src/github.com/openshift/secondary-scheduler-operator
 COPY . .
 

--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -1,8 +1,8 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/secondary-scheduler-operator
 COPY . .
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.11
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.12
 COPY --from=builder /go/src/github.com/openshift/secondary-scheduler-operator/manifests /manifests
 COPY --from=builder /go/src/github.com/openshift/secondary-scheduler-operator/metadata /metadata
 

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/secondary-scheduler-operator
 COPY . .
 
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.11
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.12
 COPY --from=builder /go/src/github.com/openshift/secondary-scheduler-operator/secondary-scheduler-operator /usr/bin/
 # Upstream bundle and index images does not support versioning so
 # we need to copy a specific version under /manifests layout directly


### PR DESCRIPTION
4.12 is built with golang v1.18