### PR TITLE
Reuse existing informer factory for namespaces when listing a config map

### DIFF
--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -7,6 +7,7 @@ rules:
   - operator.openshift.io
   resources:
   - secondaryschedulers
+  - secondaryschedulers/status
   verbs:
   - "*"
 - apiGroups:

--- a/deploy/04_kube-scheduler-cluster-role-binding.yaml
+++ b/deploy/04_kube-scheduler-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secondary-scheduler-system-kube-scheduler-role-binding
+subjects:
+- kind: ServiceAccount
+  name: secondary-scheduler-operator
+  namespace: openshift-secondary-scheduler-operator
+roleRef:
+  kind: ClusterRole
+  name: system:kube-scheduler
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/04_volume-scheduler-cluster-role-binding.yaml
+++ b/deploy/04_volume-scheduler-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secondary-scheduler-system-volume-scheduler-role-binding
+subjects:
+- kind: ServiceAccount
+  name: secondary-scheduler-operator
+  namespace: openshift-secondary-scheduler-operator
+roleRef:
+  kind: ClusterRole
+  name: system:volume-scheduler
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 
 	openshiftrouteclientset "github.com/openshift/client-go/route/clientset/versioned"
@@ -50,7 +49,6 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		return err
 	}
 	operatorConfigInformers := operatorclientinformers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
-	sharedInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	secondarySchedulerClient := &operatorclient.SecondarySchedulerClient{
 		Ctx:            ctx,
 		SharedInformer: operatorConfigInformers.Secondaryschedulers().V1().SecondarySchedulers().Informer(),
@@ -72,7 +70,6 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		osrClient,
 		dynamicClient,
 		cc.EventRecorder,
-		sharedInformerFactory,
 	)
 
 	logLevelController := loglevel.NewClusterOperatorLoggingController(secondarySchedulerClient, cc.EventRecorder)


### PR DESCRIPTION
Fixes: https://github.com/openshift/secondary-scheduler-operator/issues/74