### PR TITLE
WRKLDS-650: e2e: deploy the operator from the pipeline built image

### DIFF
--- a/test/e2e/bindata/assets/02_serviceaccount.yaml
+++ b/test/e2e/bindata/assets/02_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secondary-scheduler-operator
+  namespace: openshift-secondary-scheduler-operator

--- a/test/e2e/bindata/assets/03_clusterrole.yaml
+++ b/test/e2e/bindata/assets/03_clusterrole.yaml
@@ -1,0 +1,32 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secondary-scheduler-operator
+rules:
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - secondaryschedulers
+  - secondaryschedulers/status
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - configmaps
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"

--- a/test/e2e/bindata/assets/04_clusterrolebinding.yaml
+++ b/test/e2e/bindata/assets/04_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secondary-scheduler-operator-role-binding
+subjects:
+- kind: ServiceAccount
+  name: secondary-scheduler-operator
+  namespace: openshift-secondary-scheduler-operator
+roleRef:
+  kind: ClusterRole
+  name: secondary-scheduler-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/bindata/assets/04_kube-scheduler-cluster-role-binding.yaml
+++ b/test/e2e/bindata/assets/04_kube-scheduler-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secondary-scheduler-system-kube-scheduler-role-binding
+subjects:
+- kind: ServiceAccount
+  name: secondary-scheduler-operator
+  namespace: openshift-secondary-scheduler-operator
+roleRef:
+  kind: ClusterRole
+  name: system:kube-scheduler
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/bindata/assets/04_volume-scheduler-cluster-role-binding.yaml
+++ b/test/e2e/bindata/assets/04_volume-scheduler-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secondary-scheduler-system-volume-scheduler-role-binding
+subjects:
+- kind: ServiceAccount
+  name: secondary-scheduler-operator
+  namespace: openshift-secondary-scheduler-operator
+roleRef:
+  kind: ClusterRole
+  name: system:volume-scheduler
+  apiGroup: rbac.authorization.k8s.io

--- a/test/e2e/bindata/assets/05_deployment.yaml
+++ b/test/e2e/bindata/assets/05_deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secondary-scheduler-operator
+  namespace: openshift-secondary-scheduler-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: secondary-scheduler-operator
+  template:
+    metadata:
+      labels:
+        name: secondary-scheduler-operator
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: secondary-scheduler-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          image: # Value set in e2e
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - secondary-scheduler-operator
+          args:
+          - "operator"
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: "secondary-scheduler-operator"
+      serviceAccountName: secondary-scheduler-operator
+      serviceAccount: secondary-scheduler-operator


### PR DESCRIPTION
Deploy the secondary scheduler operator from a PR built image.
This way any change made to the operator gets tested as part of a PR.

Note: `IMAGE_FORMAT` env is deprecated. Once the env is gone it can be replaced by `RELEASE_IMAGE_LATEST` which contains the registry as well.