### PR TITLE
Sync with 4.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The Secondary Scheduler Operator provides the ability to deploy a customized sch
 | 1.0.1        | 4.10, 4.11  |
 | 1.1.0        | 4.12, 4.13  |
 | 1.1.1        | 4.13        |
-| 1.1.1        | 4.12, 4.13  |
+| 1.1.2        | 4.12, 4.13  |
+| 1.2.0        | 4.14, 4.15  |
 
 ## Deploy the Operator
 

--- a/cmd/secondary-scheduler-operator/main.go
+++ b/cmd/secondary-scheduler-operator/main.go
@@ -12,7 +12,10 @@ import (
 func main() {
 	command := NewSecondarySchedulerOperatorCommand()
 	if err := command.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		_, err := fmt.Fprintf(os.Stderr, "%v\n", err)
+		if err != nil {
+			fmt.Printf("Unable to print err to stderr: %v", err)
+		}
 		os.Exit(1)
 	}
 }
@@ -22,7 +25,10 @@ func NewSecondarySchedulerOperatorCommand() *cobra.Command {
 		Use:   "secondary-scheduler-operator",
 		Short: "OpenShift cluster secondary-scheduler operator",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
+			err := cmd.Help()
+			if err != nil {
+				fmt.Printf("Unable to print help: %v", err)
+			}
 			os.Exit(1)
 		},
 	}

--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     certified: "false"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/secondary-scheduler-operator-rhel-8:latest
     createdAt: 2023/10/23
-    olm.skipRange: ">=1.0.0 <1.2.0"
+    olm.skipRange: ">=1.1.0 <1.2.0"
     description: Runs a secondary scheduler in an OpenShift cluster.
     repository: https://github.com/openshift/secondary-scheduler-operator
     support: Red Hat, Inc.
@@ -31,6 +31,7 @@ metadata:
     categories: OpenShift Optional
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
 spec:
+  replaces: secondaryscheduleroperator.v1.1.2
   customresourcedefinitions:
     owned:
     - displayName: Secondary Scheduler

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -60,7 +60,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		return err
 	}
 
-	targetConfigReconciler := NewTargetConfigReconciler(
+	targetConfigReconciler, err := NewTargetConfigReconciler(
 		ctx,
 		operatorConfigClient.SecondaryschedulersV1(),
 		operatorConfigInformers.Secondaryschedulers().V1().SecondarySchedulers(),
@@ -71,6 +71,9 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		dynamicClient,
 		cc.EventRecorder,
 	)
+	if err != nil {
+		return err
+	}
 
 	logLevelController := loglevel.NewClusterOperatorLoggingController(secondarySchedulerClient, cc.EventRecorder)
 


### PR DESCRIPTION
Keeping the release-4.14 in sync with master:HEAD before we start rebasing to k8s 1.28. After 1.2.0 is out release-4.14 will no longer accept any changes unless decided otherwise.