### PR TITLE
OCPBUGS-23328: Align resource limits and requests with the default kube-scheduler

### DIFF
--- a/bindata/assets/secondary-scheduler/deployment.yaml
+++ b/bindata/assets/secondary-scheduler/deployment.yaml
@@ -35,12 +35,9 @@ spec:
           - name: ENABLE_OPENSHIFT_AUTH
             value: "true"
           resources:
-            limits:
-              cpu: "100m"
-              memory: "500Mi"
             requests:
-              cpu: "100m"
-              memory: "500Mi"
+              cpu: 15m
+              memory: 50Mi
           args:
             - /bin/kube-scheduler
             - --config=/etc/kubernetes/config.yaml


### PR DESCRIPTION
Aligned with https://github.com/openshift/cluster-kube-scheduler-operator/blob/ff72afc0cc93006c6d647919873bbec1740110f0/bindata/assets/kube-scheduler/pod.yaml#L43-L46