### PR TITLE
OCPBUGS-28584: deploy: add get/list/watch permissions to infrastructure object

### DIFF
--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -40,3 +40,11 @@ rules:
   - list
   - create
   - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -125,6 +125,14 @@ spec:
           - list
           - create
           - update
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
+          - list
+          - watch
       deployments:
       - name: secondary-scheduler-operator
         spec:


### PR DESCRIPTION
this is used by library-go `ControllerBuilder.Run` to discover cluster topology and setup leader election based on that.

--

There isn't a lot of use in this for this operator as I doubt SNO clusters will be using the secondary scheduler 🤔 
Regardless, this PR should silent the warn seen in the logs.