### PR TITLE
Operator deployment: set an emptyDir /tmp

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -1,8 +1,8 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/secondary-scheduler-operator
 COPY . .
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.14
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16
 COPY --from=builder /go/src/github.com/openshift/secondary-scheduler-operator/manifests /manifests
 COPY --from=builder /go/src/github.com/openshift/secondary-scheduler-operator/metadata /metadata
 

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/secondary-scheduler-operator
 COPY . .
 
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.14
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16
 COPY --from=builder /go/src/github.com/openshift/secondary-scheduler-operator/secondary-scheduler-operator /usr/bin/
 # Upstream bundle and index images does not support versioning so
 # we need to copy a specific version under /manifests layout directly

--- a/deploy/05_deployment.yaml
+++ b/deploy/05_deployment.yaml
@@ -40,5 +40,11 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "secondary-scheduler-operator"
+          volumeMounts:
+          - name: tmp
+            mountPath: "/tmp"
       serviceAccountName: secondary-scheduler-operator
       serviceAccount: secondary-scheduler-operator
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -186,6 +186,12 @@ spec:
                           fieldPath: metadata.namespace
                     - name: OPERATOR_NAME
                       value: "secondary-scheduler-operator"
+                  volumeMounts:
+                  - name: tmp
+                    mountPath: "/tmp"
               serviceAccountName: secondary-scheduler-operator
               serviceAccount: openshift-secondary-scheduler-operator
+              volumes:
+              - name: tmp
+                emptyDir: {}
     strategy: deployment

--- a/test/e2e/bindata/assets/05_deployment.yaml
+++ b/test/e2e/bindata/assets/05_deployment.yaml
@@ -21,6 +21,7 @@ spec:
         - name: secondary-scheduler-operator
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           image: # Value set in e2e
@@ -39,5 +40,11 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "secondary-scheduler-operator"
+          volumeMounts:
+          - name: tmp
+            mountPath: "/tmp"
       serviceAccountName: secondary-scheduler-operator
       serviceAccount: secondary-scheduler-operator
+      volumes:
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
readOnlyRootFilesystem SecurityContext is enabled by default in Deployment object definition. As a result, /tmp is read-only and not writable.