### PR TITLE
WRKLDS-1231: CSV: set skips to allow to add patch releases into all supported bundle index images

### DIFF
--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    olm.skipRange: ">=1.2.1 <1.3.1"
+    olm.skipRange: ">=1.2.0 <1.3.1"
     description: Runs a secondary scheduler in an OpenShift cluster.
     repository: https://github.com/openshift/secondary-scheduler-operator
     support: Red Hat, Inc.
@@ -41,7 +41,18 @@ metadata:
     categories: OpenShift Optional
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
 spec:
-  replaces: secondaryscheduleroperator.v1.3.0
+  replaces: secondaryscheduleroperator.v1.2.0
+  # buffering up to 6 1.2.z releases to allow to include these in all supported bundle index images
+  # The buffer len 6 should be sufficient for normal cadance. Including CVE releases.
+  # The buffer can be extened later as needed.
+  skips:
+  - secondaryscheduleroperator.v1.2.1
+  - secondaryscheduleroperator.v1.2.2
+  - secondaryscheduleroperator.v1.2.3
+  - secondaryscheduleroperator.v1.2.4
+  - secondaryscheduleroperator.v1.2.5
+  - secondaryscheduleroperator.v1.2.6
+  - secondaryscheduleroperator.v1.3.0
   customresourcedefinitions:
     owned:
     - displayName: Secondary Scheduler


### PR DESCRIPTION
The first time we use a buffer for skipped releases to maintain a reachable to-be-added-patch-releases in the future so `opm index add` is happy to accept the patch releases for all existing index bundle images.