### PR TITLE
WRKLDS-1393: CSV: set skips to allow to add patch releases into all supported bundle index images

### DIFF
--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -41,7 +41,19 @@ metadata:
     categories: OpenShift Optional
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
 spec:
-  replaces: secondaryscheduleroperator.v1.2.1
+  replaces: secondaryscheduleroperator.v1.1.0
+  # buffering up to 6 1.1.z releases to allow to include these in all supported bundle index images
+  # The buffer len 6 should be sufficient for normal cadance. Including CVE releases.
+  # The buffer can be extened later as needed.
+  skips:
+  - secondaryscheduleroperator.v1.1.1
+  - secondaryscheduleroperator.v1.1.2
+  - secondaryscheduleroperator.v1.1.3
+  - secondaryscheduleroperator.v1.1.4
+  - secondaryscheduleroperator.v1.1.5
+  - secondaryscheduleroperator.v1.1.6
+  - secondaryscheduleroperator.v1.2.0
+  - secondaryscheduleroperator.v1.2.1
   customresourcedefinitions:
     owned:
     - displayName: Secondary Scheduler


### PR DESCRIPTION
The first time we use a buffer for skipped releases to maintain a reachable to-be-added-patch-releases in the future so `opm index add` is happy to accept the patch releases for all existing index bundle images.