### PR TITLE
OCPBUGS-38317: scheduler-plugins change causes CrashLoopBackOff

### DIFF
--- a/bindata/assets/secondary-scheduler/deployment.yaml
+++ b/bindata/assets/secondary-scheduler/deployment.yaml
@@ -39,8 +39,9 @@ spec:
             requests:
               cpu: 15m
               memory: 50Mi
-          args:
+          command: 
             - /bin/kube-scheduler
+          args:
             - --config=/etc/kubernetes/config.yaml
           volumeMounts:
             - mountPath: "/etc/kubernetes"


### PR DESCRIPTION
Fixes an issue with /bin/kube-scheduler path and scheduler-plugins image