### PR TITLE
no-jira: Run prefetch dependencies

### DIFF
--- a/.tekton/secondary-scheduler-operator-bundle-4-17-pull-request.yaml
+++ b/.tekton/secondary-scheduler-operator-bundle-4-17-pull-request.yaml
@@ -245,7 +245,7 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(tasks.init.results.build)
+      - input: $(params.hermetic)
         operator: in
         values:
         - "true"

--- a/.tekton/secondary-scheduler-operator-bundle-4-17-push.yaml
+++ b/.tekton/secondary-scheduler-operator-bundle-4-17-push.yaml
@@ -242,7 +242,7 @@ spec:
           value: task
         resolver: bundles
       when:
-      - input: $(tasks.init.results.build)
+      - input: $(params.hermetic)
         operator: in
         values:
         - "true"


### PR DESCRIPTION
```
✕ [Violation] tasks.required_tasks_found
  ImageRef: quay.io/redhat-user-workloads/crt-nshift-secondary-tenant/secondary-scheduler-operator-4-17/secondary-scheduler-operator-bundle-4-17@sha256:48ba0813c54273b49c820988e8bcc58a9ed47798774640ed663ec438448e069b
  Reason: One of "prefetch-dependencies", "prefetch-dependencies-oci-ta" tasks is missing
  Title: All required tasks were included in the pipeline
  Description: Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add one or
  more of "tasks.required_tasks_found:prefetch-dependencies", "tasks.required_tasks_found:prefetch-dependencies-oci-ta" to the
  `exclude` section of the policy configuration.
  Solution: Make sure all required tasks are in the build pipeline. The required task list is contained as
  xref:ec-cli:ROOT:configuration.adoc#_data_sources[data] under the key 'required-tasks'.
```