### PR TITLE
OCPBUGS-44204: Operator deployment: set an emptyDir /tmp

### DIFF
--- a/deploy/05_deployment.yaml
+++ b/deploy/05_deployment.yaml
@@ -40,5 +40,11 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "secondary-scheduler-operator"
+          volumeMounts:
+          - name: tmp
+            mountPath: "/tmp"
       serviceAccountName: secondary-scheduler-operator
       serviceAccount: secondary-scheduler-operator
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -198,6 +198,12 @@ spec:
                           fieldPath: metadata.namespace
                     - name: OPERATOR_NAME
                       value: "secondary-scheduler-operator"
+                  volumeMounts:
+                  - name: tmp
+                    mountPath: "/tmp"
               serviceAccountName: secondary-scheduler-operator
               serviceAccount: openshift-secondary-scheduler-operator
+              volumes:
+              - name: tmp
+                emptyDir: {}
     strategy: deployment

--- a/test/e2e/bindata/assets/05_deployment.yaml
+++ b/test/e2e/bindata/assets/05_deployment.yaml
@@ -21,6 +21,7 @@ spec:
         - name: secondary-scheduler-operator
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           image: # Value set in e2e
@@ -39,5 +40,11 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "secondary-scheduler-operator"
+          volumeMounts:
+          - name: tmp
+            mountPath: "/tmp"
       serviceAccountName: secondary-scheduler-operator
       serviceAccount: secondary-scheduler-operator
+      volumes:
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
readOnlyRootFilesystem SecurityContext is enabled by default in Deployment object definition. As a result, /tmp is read-only and not writable.