### PR TITLE
no-jira: Set suggested-namespace and related annotations

### DIFF
--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -45,6 +45,9 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: "openshift-secondary-scheduler-operator"
+    console.openshift.io/operator-monitoring-default: "true"
 spec:
   replaces: secondaryscheduleroperator.v1.2.0
   # buffering up to 6 1.2.z releases to allow to include these in all supported bundle index images


### PR DESCRIPTION
Add a few annotations:
- operatorframework.io/cluster-monitoring: "true"
- operatorframework.io/suggested-namespace: "openshift-kube-descheduler-operator"
- console.openshift.io/operator-monitoring-default: "true" to simplify the deployment via OCP console.