### PR TITLE
drop unusued functions

### DIFF
--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -168,23 +168,6 @@ func (c TargetConfigReconciler) sync(item queueItem) error {
 	return err
 }
 
-func (c *TargetConfigReconciler) manageConfigMap(secondaryScheduler *secondaryschedulersv1.SecondaryScheduler) (*v1.ConfigMap, bool, error) {
-	var required *v1.ConfigMap
-	var err error
-
-	required, err = c.kubeClient.CoreV1().ConfigMaps(secondaryScheduler.Namespace).Get(context.TODO(), string(secondaryScheduler.Spec.SchedulerConfig), metav1.GetOptions{})
-
-	if err != nil {
-		klog.Errorf("Cannot load ConfigMap %s for the secondaryscheduler", string(secondaryScheduler.Spec.SchedulerConfig))
-		return nil, false, err
-	}
-
-	secondarySchedulerConfigMap = string(secondaryScheduler.Spec.SchedulerConfig)
-	klog.Infof("Find ConfigMap %s for the secondaryscheduler.", secondaryScheduler.Spec.SchedulerConfig)
-
-	return resourceapply.ApplyConfigMap(c.ctx, c.kubeClient.CoreV1(), c.eventRecorder, required)
-}
-
 func (c *TargetConfigReconciler) getConfigMapResourceVersion(secondaryScheduler *secondaryschedulersv1.SecondaryScheduler) (string, error) {
 	required, err := c.kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister().ConfigMaps(operatorclient.OperatorNamespace).Get(secondaryScheduler.Spec.SchedulerConfig)
 	if err != nil {


### PR DESCRIPTION
I am using this code as a template for KueueOperator.

As I was reading this code, I noticed that we don't actually use this function in the code.

This seems like a bug to me?

Bringing up the PR as a discussion point to better understand how changing the configmap will actually trigger a new configmap sync?