### PR TITLE
OCPBUGS-58154: secondary-scheduler: Configure tmp volume in case a secondary scheduler framework wants to creat a temp dir/file

### DIFF
--- a/bindata/assets/secondary-scheduler/deployment.yaml
+++ b/bindata/assets/secondary-scheduler/deployment.yaml
@@ -23,6 +23,8 @@ spec:
         - name: "etckubernetes"
           configMap:
             name: ${CONFIGMAP}
+        - name: tmp
+          emptyDir: {}
       restartPolicy: "Always"
       containers:
         - name: "secondary-scheduler"
@@ -39,11 +41,13 @@ spec:
             requests:
               cpu: 15m
               memory: 50Mi
-          command: 
+          command:
             - /bin/kube-scheduler
           args:
             - --config=/etc/kubernetes/config.yaml
           volumeMounts:
             - mountPath: "/etc/kubernetes"
               name: "etckubernetes"
+            - name: tmp
+              mountPath: "/tmp"
       serviceAccountName: "secondary-scheduler"

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -260,6 +260,9 @@ func (c *TargetConfigReconciler) manageDeployment(secondaryScheduler *secondarys
 
 	for i := range required.Spec.Template.Spec.Volumes {
 		for pat, configmap := range configmaps {
+			if required.Spec.Template.Spec.Volumes[i].ConfigMap == nil {
+				continue
+			}
 			if required.Spec.Template.Spec.Volumes[i].ConfigMap.Name == pat {
 				required.Spec.Template.Spec.Volumes[i].ConfigMap.Name = configmap
 				break


### PR DESCRIPTION
readOnlyRootFilesystem SecurityContext is enabled by default in Deployment object definition. As a result, /tmp is read-only and not writable.