### PR TITLE
feat(.tekton): add DAST integration test pipeline for OSSO 4.21

### DIFF
--- a/.tekton/integration-tests/README.md
+++ b/.tekton/integration-tests/README.md
@@ -1,0 +1,140 @@
+# OSSO DAST Integration Tests on Konflux
+
+## Overview
+
+This directory contains the DAST (Dynamic Application Security Testing) pipeline for the
+Secondary Scheduler Operator (OSSO) on Konflux. The pipeline runs automatically when the OSSO
+bundle image is built, provisioning an ephemeral OCP cluster and executing security scans.
+
+## Pipeline
+
+**File:** `pipelines/secondary-scheduler-operator-dast-pipeline-4-21.yaml`
+
+### What it does
+
+1. **Provisions** an ephemeral OCP 4.21 cluster via EaaS (Environment as a Service)
+2. **Installs** the OSSO operator from the Konflux-built SNAPSHOT bundle using `operator-sdk run bundle`
+3. **Creates** a scheduler config ConfigMap and applies an enriched `SecondaryScheduler` CR
+   with all spec fields populated to maximize test coverage
+4. **Runs oobtkube** (out-of-box testing for Kubernetes) as a Job on the ephemeral cluster to detect
+   blind command injection vulnerabilities in the operator's CR reconciliation logic
+5. **Runs Trivy** misconfiguration scan against deployed OSSO workloads
+6. **Uploads results** to GCS (`secaut-bucket`) and surfaces findings in the Konflux UI
+   via `TEST_OUTPUT` / `SCAN_OUTPUT` task results
+
+### Architecture
+
+```
+Konflux Build Pipeline
+        |
+        v  (SNAPSHOT with bundle image)
+IntegrationTestScenario (konflux-release-data)
+        |
+        v  (git resolver)
+DAST Pipeline (this repo)
+        |
+        +-- parse-metadata
+        +-- eaas-provision-space (ownerKind: PipelineRun)
+        +-- provision-cluster (OCP 4.21 + imageContentSources)
+        +-- install-osso-operator (operator-sdk run bundle from SNAPSHOT)
+        +-- dast-test
+              +-- get-kubeconfig
+              +-- orchestrate-dast (oc: ns, RBAC, ConfigMap, RapiDAST Job)
+              +-- post-process (TEST_OUTPUT + SCAN_OUTPUT)
+```
+
+oobtkube runs **on the ephemeral cluster** as a Kubernetes Job (not as a Tekton step).
+This ensures the oobtkube TCP listener and the OSSO operator share the same network,
+allowing the callback mechanism to work correctly.
+
+### Container images used
+
+| Step | Image | Why |
+|------|-------|-----|
+| install-operator, orchestrate-dast, post-process | `quay.io/konflux-ci/konflux-test:latest` | Has `oc`, `kubectl`, `jq`, `/utils.sh` |
+| RapiDAST Job (on ephemeral cluster) | `quay.io/redhatproductsecurity/rapidast:latest` | Has `rapidast.py`, `oobtkube.py` (via `python3.12`), `trivy`, `kubectl` |
+| results-fetcher | `registry.access.redhat.com/ubi9/ubi:latest` | Pod to mount PVC for `oc cp` (needs `tar`) |
+
+## Prerequisites
+
+### GCS Secret
+
+A Google Cloud Storage service account key must be provisioned in the `crt-nshift-secondary-tenant`
+namespace on the Konflux cluster:
+
+- **Secret name:** `rapidast-sa-osso-key`
+- **Key:** `sa-key` (JSON service account credentials)
+- **Bucket:** `secaut-bucket`
+
+Request access via the SecAut Bucket Access Repository (same process as KDO).
+
+### IntegrationTestScenario
+
+The ITS resource `secondary-scheduler-operator-4-21-dast` must exist in
+`konflux-release-data` under the `crt-nshift-secondary-tenant`. It is configured with:
+
+- `test.appstudio.openshift.io/optional: "true"` label (non-blocking)
+- Context filter: `component_secondary-scheduler-operator-bundle-4-21` (triggers on bundle builds)
+- Param: `osso_version: "4.21"` (for GCS path tagging)
+
+### imageContentSources
+
+The ephemeral cluster is configured with image content source mirrors so that
+`operator-sdk run bundle` can pull images built by Konflux:
+
+| Registry source | Konflux mirror |
+|----------------|----------------|
+| `registry.redhat.io/openshift-secondary-scheduler-operator/secondary-scheduler-rhel9-operator` | `quay.io/redhat-user-workloads/crt-nshift-secondary-tenant/secondary-scheduler-operator-4-21` |
+| `registry.redhat.io/openshift-secondary-scheduler-operator/secondary-scheduler-operator-bundle` | `quay.io/redhat-user-workloads/crt-nshift-secondary-tenant/secondary-scheduler-operator-bundle-4-21` |
+
+## Interpreting Results
+
+### Konflux UI
+
+- **TEST_OUTPUT**: Shows `SUCCESS` if the pipeline completed. Check `SCAN_OUTPUT` for details.
+- **SCAN_OUTPUT**: JSON with vulnerability counts by severity (critical/high/medium/low).
+
+### GCS Archive
+
+Results are uploaded to `gs://secaut-bucket/osso/<version>/oobtkube/` by RapiDAST's
+native `google.cloud.storage` integration. Contains the full SARIF report.
+
+### oobtkube Findings
+
+oobtkube detects blind command injection by injecting `curl <pod-ip>:<port>` payloads
+into CR string fields. The pod IP is injected via the Kubernetes downward API (`POD_IP` env var).
+If the operator executes any injected command, oobtkube's listener receives the callback
+and reports a finding. Any finding indicates a critical vulnerability.
+
+The scanner is configured as `generic_oobtkube` in RapiDAST (using the `generic_<name>` pattern)
+and uses `python3.12` (the default `python3` in the RapiDAST image lacks `pyyaml`).
+
+### Trivy Findings
+
+Trivy scans deployed OSSO workloads for Kubernetes misconfigurations (HIGH/CRITICAL severity).
+Results are saved as JSON in the shared volume.
+
+## Enriched CR
+
+The test uses an enriched `SecondaryScheduler` CR with maximum field coverage:
+
+- **schedulerConfig**: References a ConfigMap (`secondary-scheduler-config`) created by the
+  pipeline before the CR is applied
+- **schedulerImage**: Points to the upstream kube-scheduler plugins image
+- **logLevel/operatorLogLevel**: Set to Debug for maximum operator reconciliation coverage
+- **topology.highlyAvailableTopology**: Includes `maxReplicas`, `nodeSelector`, and
+  `tolerations` fields for additional oobtkube injection surface
+
+Key oobtkube injection targets are `schedulerConfig` and `schedulerImage` (free-form strings).
+
+## Known Limitations
+
+- **Trivy namespace flag**: Trivy k8s uses `--include-namespaces` (not `--namespace`).
+- **`python3.12` required for oobtkube**: The RapiDAST image's default `python3` (3.9) lacks
+  `pyyaml`. The config must use `python3.12` for the oobtkube inline command.
+- **`hostname` unavailable in RapiDAST container**: Pod IP must be injected via the Kubernetes
+  downward API (`POD_IP` env var) instead of `$(hostname -i)`.
+- **Scheduler ConfigMap dependency**: The enriched CR references a ConfigMap that must exist
+  before the CR is applied. The pipeline creates this ConfigMap in step 6 of orchestrate-dast.
+- **Non-hermetic**: Integration test pipelines on Konflux are not subject to hermetic build
+  constraints. Runtime downloads and `:latest` tags are acceptable per Konflux docs.

--- a/.tekton/integration-tests/configs/osso-cr.yaml
+++ b/.tekton/integration-tests/configs/osso-cr.yaml
@@ -1,0 +1,20 @@
+apiVersion: operator.openshift.io/v1
+kind: SecondaryScheduler
+metadata:
+  name: cluster
+  namespace: openshift-secondary-scheduler-operator
+spec:
+  managementState: Managed
+  logLevel: "Debug"
+  operatorLogLevel: "Debug"
+  schedulerConfig: "secondary-scheduler-config"
+  schedulerImage: "registry.k8s.io/scheduler-plugins/kube-scheduler:v0.33.5"
+  topology:
+    highlyAvailableTopology:
+      maxReplicas: 3
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"

--- a/.tekton/integration-tests/configs/rapidast-job.yaml
+++ b/.tekton/integration-tests/configs/rapidast-job.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rapidast-osso-oobtkube
+  namespace: rapidast-osso
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: privileged-sa
+      containers:
+        - name: rapidast
+          image: quay.io/redhatproductsecurity/rapidast:latest
+          imagePullPolicy: Always
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              rapidast.py --log-level debug --config /opt/rapidast/config/rapidastconfig.yaml
+              RESULT=$?
+              cp /opt/rapidast/results/*.sarif /opt/rapidast/pvc-results/ 2>/dev/null || true
+              cp /opt/rapidast/results/*.json /opt/rapidast/pvc-results/ 2>/dev/null || true
+              exit $RESULT
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /opt/rapidast/config
+            - name: results
+              mountPath: /opt/rapidast/pvc-results
+            - name: gcs-key
+              mountPath: /etc/gcs
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: rapidast-osso-config
+        - name: results
+          persistentVolumeClaim:
+            claimName: rapidast-pvc
+        - name: gcs-key
+          secret:
+            secretName: rapidast-sa-osso-key
+      restartPolicy: Never

--- a/.tekton/integration-tests/configs/rapidastconfig.yaml
+++ b/.tekton/integration-tests/configs/rapidastconfig.yaml
@@ -1,0 +1,25 @@
+config:
+  configVersion: 6
+  googleCloudStorage:
+    keyFile: "/etc/gcs/sa-key"
+    bucketName: "secaut-bucket"
+    directory: "osso/${OSSO_VERSION}"
+
+application:
+  shortName: "osso"
+  url: "https://kubernetes.default.svc"
+
+general:
+  container:
+    type: "none"
+
+scanners:
+  generic_oobtkube:
+    results: "/opt/rapidast/results/oobtkube-results.sarif"
+    inline: |
+      python3.12 oobtkube.py --find-all --log-level debug -d 300 -p 6000 -i ${POD_IP} -f /opt/rapidast/config/osso-cr.yaml -o /opt/rapidast/results/oobtkube-results.sarif
+
+  generic_trivy:
+    results: "/opt/rapidast/results/trivy-results.json"
+    inline: |
+      trivy k8s --include-namespaces openshift-secondary-scheduler-operator --scanners=misconfig --severity HIGH,CRITICAL --report all --format json --output /opt/rapidast/results/trivy-results.json --skip-check-update

--- a/.tekton/integration-tests/pipelines/secondary-scheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/secondary-scheduler-operator-dast-pipeline-4-21.yaml
@@ -1,0 +1,470 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: secondary-scheduler-operator-dast-pipeline
+spec:
+  description: |
+    DAST pipeline for Secondary Scheduler Operator (OSSO) on Konflux.
+    Provisions an ephemeral OCP 4.21 cluster, installs OSSO from SNAPSHOT bundle,
+    runs oobtkube (blind command injection testing via RapiDAST) as a Job on the
+    ephemeral cluster, and Trivy for misconfiguration scanning. Results are uploaded
+    to GCS and surfaced in Konflux UI via TEST_OUTPUT/SCAN_OUTPUT.
+  params:
+    - name: SNAPSHOT
+      description: "The JSON string representing the snapshot of the application under test."
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: osso_version
+      description: "OSSO product version used to tag RapiDAST scan results in GCS"
+      type: string
+    - name: config_git_revision
+      description: "Git branch/revision used to fetch config files (rapidastconfig.yaml, osso-cr.yaml, rapidast-job.yaml). Set to a PR branch for pre-merge testing."
+      default: "main"
+      type: string
+  tasks:
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 1: parse-metadata
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: parse-metadata
+      timeout: "5m"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 2: eaas-provision-space
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: eaas-provision-space
+      timeout: "5m"
+      runAfter:
+        - parse-metadata
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 3: provision-cluster (OCP 4.21 + imageContentSources for OSSO)
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: provision-cluster
+      timeout: "35m"
+      runAfter:
+        - eaas-provision-space
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "4.20."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: "m5.xlarge"
+              - name: timeout
+                value: "30m"
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/openshift-secondary-scheduler-operator/secondary-scheduler-rhel9-operator
+                    mirrors:
+                      - quay.io/redhat-user-workloads/crt-nshift-secondary-tenant/secondary-scheduler-operator-4-21
+                  - source: registry.redhat.io/openshift-secondary-scheduler-operator/secondary-scheduler-operator-bundle
+                    mirrors:
+                      - quay.io/redhat-user-workloads/crt-nshift-secondary-tenant/secondary-scheduler-operator-bundle-4-21
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 4: install-osso-operator (from SNAPSHOT bundle via operator-sdk)
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: install-osso-operator
+      timeout: "5m"
+      runAfter:
+        - provision-cluster
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: install-operator
+            image: quay.io/konflux-ci/konflux-test:latest
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: KONFLUX_COMPONENT_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/component']
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+
+              export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+              export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.42.2
+              curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_${ARCH}
+              chmod +x operator-sdk_linux_${ARCH}
+              mv operator-sdk_linux_${ARCH} /usr/local/bin/operator-sdk
+
+              echo "KONFLUX_COMPONENT_NAME: ${KONFLUX_COMPONENT_NAME}"
+              BUNDLE_IMAGE="$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" \
+                '.components[] | select(.name == $component_name) | .containerImage' <<< "$SNAPSHOT")"
+              echo "BUNDLE_IMAGE: ${BUNDLE_IMAGE}"
+
+              oc create namespace openshift-secondary-scheduler-operator || true
+
+              operator-sdk run bundle --timeout=10m \
+                --namespace openshift-secondary-scheduler-operator \
+                "$BUNDLE_IMAGE" --verbose
+
+              oc wait --for condition=Available \
+                -n openshift-secondary-scheduler-operator \
+                deployment/secondary-scheduler-operator \
+                --timeout=120s
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 5: dast-test (oobtkube Job + Trivy + post-process)
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: dast-test
+      timeout: "10m"
+      description: DAST testing with RapiDAST oobtkube and Trivy misconfiguration scan
+      runAfter:
+        - install-osso-operator
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: osso_version
+          value: $(params.osso_version)
+        - name: config_git_revision
+          value: $(params.config_git_revision)
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+          - name: osso_version
+            type: string
+          - name: config_git_revision
+            type: string
+        results:
+          - name: TEST_OUTPUT
+            description: Tekton task test output.
+          - name: SCAN_OUTPUT
+            description: DAST scan result.
+        volumes:
+          - name: credentials
+            emptyDir: {}
+          - name: gcs-key
+            secret:
+              secretName: rapidast-sa-osso-key
+          - name: shared
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+
+          - name: orchestrate-dast
+            image: quay.io/konflux-ci/konflux-test:latest
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: OSSO_VERSION
+                value: "$(params.osso_version)"
+              - name: CONFIG_GIT_REVISION
+                value: "$(params.config_git_revision)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+              - name: gcs-key
+                mountPath: /etc/gcs
+                readOnly: true
+              - name: shared
+                mountPath: /shared
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+              trap 'echo "DAST orchestration failed"; exit 1' ERR
+
+              # --- 1. Create namespace and RBAC on ephemeral cluster ---
+              oc create namespace rapidast-osso
+              oc create sa privileged-sa -n rapidast-osso
+              oc create clusterrolebinding rapidast-privileged \
+                --clusterrole=cluster-admin --serviceaccount=rapidast-osso:privileged-sa
+
+              # --- 2. Propagate GCS secret to ephemeral cluster ---
+              oc create secret generic rapidast-sa-osso-key \
+                --from-file=sa-key=/etc/gcs/sa-key \
+                --namespace=rapidast-osso \
+                --dry-run=client -o yaml | oc apply -f -
+
+              # --- 3. Fetch config files from repo ---
+              REPO_RAW="https://raw.githubusercontent.com/openshift/secondary-scheduler-operator/${CONFIG_GIT_REVISION}"
+              CONFIG_DIR=".tekton/integration-tests/configs"
+              curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rapidastconfig.yaml" > /tmp/rapidastconfig.yaml
+              curl -sfL "${REPO_RAW}/${CONFIG_DIR}/osso-cr.yaml" > /tmp/osso-cr.yaml
+
+              # Expand ${OSSO_VERSION} in the RapiDAST config
+              export OSSO_VERSION
+              sed "s/\${OSSO_VERSION}/${OSSO_VERSION}/g" /tmp/rapidastconfig.yaml > /tmp/rapidastconfig-resolved.yaml
+
+              # --- 4. Create PVC for results on ephemeral cluster ---
+              cat <<'PVCEOF' | oc apply -f -
+              apiVersion: v1
+              kind: PersistentVolumeClaim
+              metadata:
+                name: rapidast-pvc
+                namespace: rapidast-osso
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+              PVCEOF
+
+              # --- 5. Create RapiDAST ConfigMap from fetched config files ---
+              oc create configmap rapidast-osso-config \
+                --from-file=rapidastconfig.yaml=/tmp/rapidastconfig-resolved.yaml \
+                --from-file=osso-cr.yaml=/tmp/osso-cr.yaml \
+                --namespace=rapidast-osso
+
+              # --- 6. Create scheduler config ConfigMap (required by the CR) ---
+              cat <<'CMEOF' | oc apply -f -
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: secondary-scheduler-config
+                namespace: openshift-secondary-scheduler-operator
+              data:
+                config.yaml: |
+                  apiVersion: kubescheduler.config.k8s.io/v1
+                  kind: KubeSchedulerConfiguration
+                  profiles:
+                    - schedulerName: secondary-scheduler
+                      pluginConfig:
+                        - args:
+                            scoringStrategy:
+                              type: MostAllocated
+                          name: NodeResourcesFit
+                      plugins:
+                        score:
+                          disabled:
+                          - name: "NodeResourcesBalancedAllocation"
+                          enabled:
+                          - name: "NodeResourcesFit"
+                            weight: 5
+              CMEOF
+
+              # --- 7. Apply enriched CR on ephemeral cluster (for operator to reconcile) ---
+              oc apply -f /tmp/osso-cr.yaml
+
+              # Wait for operator to reconcile the CR
+              sleep 15
+              oc wait --for condition=Available \
+                -n openshift-secondary-scheduler-operator \
+                deployment/secondary-scheduler-operator \
+                --timeout=120s
+
+              # --- 8. Create RapiDAST Job on ephemeral cluster ---
+              curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rapidast-job.yaml" > /tmp/rapidast-job.yaml
+              oc apply -f /tmp/rapidast-job.yaml
+
+              # --- 9. Wait for Job to terminate (complete or fail) ---
+              oc wait --for=condition=complete job/rapidast-osso-oobtkube \
+                -n rapidast-osso --timeout=600s 2>/dev/null \
+                || oc wait --for=condition=failed job/rapidast-osso-oobtkube \
+                -n rapidast-osso --timeout=30s 2>/dev/null \
+                || echo "Job still running after timeout"
+
+              # --- 10. Capture Job logs ---
+              oc logs job/rapidast-osso-oobtkube -n rapidast-osso > /shared/rapidast-osso-log.txt 2>&1 || true
+
+              # --- 11. Retrieve SARIF from PVC via helper pod ---
+              cat <<'CPEOF' | oc apply -f -
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: results-fetcher
+                namespace: rapidast-osso
+              spec:
+                containers:
+                  - name: fetcher
+                    image: registry.access.redhat.com/ubi9/ubi:latest
+                    command: ["sleep", "300"]
+                    volumeMounts:
+                      - name: results
+                        mountPath: /results
+                volumes:
+                  - name: results
+                    persistentVolumeClaim:
+                      claimName: rapidast-pvc
+                restartPolicy: Never
+              CPEOF
+              oc wait --for=condition=Ready pod/results-fetcher -n rapidast-osso --timeout=60s
+              oc cp rapidast-osso/results-fetcher:/results/oobtkube-results.sarif /shared/oobtkube-results.sarif || true
+              oc cp rapidast-osso/results-fetcher:/results/trivy-results.json /shared/trivy-results.json || true
+
+              echo "DAST orchestration complete. Results in /shared/"
+
+          - name: post-process
+            image: quay.io/konflux-ci/konflux-test:latest
+            volumeMounts:
+              - name: shared
+                mountPath: /shared
+            script: |
+              #!/bin/bash
+              source /utils.sh
+              trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+              scan_result='{"vulnerabilities":{"critical":0,"high":0,"medium":0,"low":0,"unknown":0}}'
+
+              # --- Parse oobtkube SARIF results ---
+              sarif_file=/shared/oobtkube-results.sarif
+              if [ -s "$sarif_file" ]; then
+                result=$(jq -rce '{
+                  vulnerabilities:{
+                    critical: ([.runs[0].results[]? | select(.level == "error")] | length),
+                    high: ([.runs[0].results[]? | select(.level == "warning")] | length),
+                    medium: ([.runs[0].results[]? | select(.level == "note")] | length),
+                    low: ([.runs[0].results[]? | select(.level == "none" or .level == null or .level == "")] | length),
+                    unknown: ([.runs[0].results[]? | select(.level != "error" and .level != "warning" and .level != "note" and .level != "none" and .level != null and .level != "")] | length)
+                  }}' "$sarif_file")
+                scan_result=$(jq -s -rce '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |
+                  .[0].vulnerabilities.high += .[1].vulnerabilities.high |
+                  .[0].vulnerabilities.medium += .[1].vulnerabilities.medium |
+                  .[0]' <<<"$scan_result $result")
+              fi
+
+              # --- Parse Trivy JSON results ---
+              trivy_file=/shared/trivy-results.json
+              if [ -s "$trivy_file" ]; then
+                trivy_result=$(jq -rce '{
+                  vulnerabilities:{
+                    critical: ([.Resources[]?.Results[]?.Misconfigurations[]? | select(.Severity == "CRITICAL")] | length),
+                    high: ([.Resources[]?.Results[]?.Misconfigurations[]? | select(.Severity == "HIGH")] | length),
+                    medium: 0,
+                    low: 0,
+                    unknown: 0
+                  }}' "$trivy_file")
+                scan_result=$(jq -s -rce '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |
+                  .[0].vulnerabilities.high += .[1].vulnerabilities.high |
+                  .[0]' <<<"$scan_result $trivy_result")
+              fi
+
+              echo "$scan_result" | tee "$(results.SCAN_OUTPUT.path)"
+
+              note="Task $(context.task.name) completed: Refer to SCAN_OUTPUT for DAST findings."
+              TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")
+              echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"


### PR DESCRIPTION
## Summary

- Adds a Konflux DAST pipeline for Secondary Scheduler Operator (OCP 4.21)
- Runs **RapiDAST oobtkube** (blind command injection testing via enriched CR) and **Trivy** misconfiguration scanning on an ephemeral EaaS cluster
- Config files are externalized under `configs/` for maintainability: RapiDAST config, enriched SecondaryScheduler CR, and RapiDAST Job spec

## Files

| File | Purpose |
| --- | --- |
| `pipelines/secondary-scheduler-operator-dast-pipeline-4-21.yaml` | Tekton Pipeline: parse-metadata, EaaS provisioning, operator install, DAST orchestration, post-process |
| `configs/rapidastconfig.yaml` | RapiDAST `generic_oobtkube` scanner config (uses `python3.12`, `POD_IP` via downward API) |
| `configs/osso-cr.yaml` | Enriched SecondaryScheduler CR with all spec fields populated for maximum oobtkube injection coverage |
| `configs/rapidast-job.yaml` | RapiDAST Job spec (runs on ephemeral cluster, writes SARIF to PVC, uploads to GCS) |

## Test plan

- [ ] Validate locally on CRC (OCP 4.21) with real Quay bundle image
- [ ] oobtkube tests all CR leaf keys, 0 command injection findings expected
- [ ] Trivy scans OSSO namespace, 0 HIGH/CRITICAL misconfigurations expected
- [ ] SARIF output produced and retrievable from PVC
- [ ] Requires `IntegrationTestScenario` in `konflux-release-data` (optional, non-blocking)
- [ ] Requires GCS secret `rapidast-sa-osso-key` in `crt-nshift-secondary-tenant` namespace