### PR TITLE
fix(.tekton): increase install-osso-operator timeout to 10m

### DIFF
--- a/.tekton/integration-tests/pipelines/secondary-scheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/secondary-scheduler-operator-dast-pipeline-4-21.yaml
@@ -143,7 +143,7 @@ spec:
     # Task 4: install-osso-operator (from SNAPSHOT bundle via operator-sdk)
     # ──────────────────────────────────────────────────────────────────────────
     - name: install-osso-operator
-      timeout: "5m"
+      timeout: "10m"
       runAfter:
         - provision-cluster
       when:


### PR DESCRIPTION
## Summary

- Increases the `install-osso-operator` task timeout from 5m to 10m
- The 5m timeout was insufficient for `operator-sdk run bundle` to complete on ephemeral EaaS clusters, causing `TaskRunTimeout` failures

## Evidence

Preemptive fix based on the same issue observed in the RODOO DAST pipeline where `operator-sdk run bundle` exceeded the 5m timeout on an ephemeral EaaS cluster.