### PR TITLE
NO-JIRA: add SCC annotations, terminationMessagePolicy, image, del ns logic

### DIFF
--- a/bindata/assets/secondary-scheduler/deployment.yaml
+++ b/bindata/assets/secondary-scheduler/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       app: "secondary-scheduler"
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         app: "secondary-scheduler"
     spec:
@@ -37,6 +39,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           image: ${IMAGE}
+          terminationMessagePolicy: FallbackToLogsOnError
           command:
             - /bin/kube-scheduler
           args:

--- a/deploy/05_deployment.yaml
+++ b/deploy/05_deployment.yaml
@@ -10,6 +10,8 @@ spec:
       name: secondary-scheduler-operator
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         name: secondary-scheduler-operator
     spec:
@@ -25,6 +27,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           image: quay.io/openshift/secondary-scheduler-operator:4.17
+          terminationMessagePolicy: FallbackToLogsOnError
           ports:
           - containerPort: 60000
             name: metrics

--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -248,6 +248,8 @@ spec:
                 name: secondary-scheduler-operator
             template:
               metadata:
+                annotations:
+                  openshift.io/required-scc: restricted-v2
                 labels:
                   name: secondary-scheduler-operator
               spec:
@@ -263,6 +265,7 @@ spec:
                       capabilities:
                         drop: ["ALL"]
                     image: registry-proxy.engineering.redhat.com/rh-osbs/secondary-scheduler-rhel9-operator:latest
+                    terminationMessagePolicy: FallbackToLogsOnError
                     resources:
                       requests:
                         memory: 50Mi

--- a/test/e2e/bindata/assets/05_deployment.yaml
+++ b/test/e2e/bindata/assets/05_deployment.yaml
@@ -10,6 +10,8 @@ spec:
       name: secondary-scheduler-operator
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         name: secondary-scheduler-operator
     spec:
@@ -25,6 +27,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           image: # Value set in e2e
+          terminationMessagePolicy: FallbackToLogsOnError
           ports:
           - containerPort: 60000
             name: metrics

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -346,8 +346,8 @@ func testScheduling(t testing.TB, ctx context.Context, kubeClient *k8sclient.Cli
 					},
 				},
 				Name:            "pause",
-				ImagePullPolicy: "Always",
-				Image:           "kubernetes/pause",
+				ImagePullPolicy: "IfNotPresent",
+				Image:           "registry.k8s.io/pause:3.10",
 				Ports:           []corev1.ContainerPort{{ContainerPort: 80}},
 			}},
 		},
@@ -382,7 +382,12 @@ func cleanupTestNamespace(t testing.TB, ctx context.Context, kubeClient *k8sclie
 	}
 	klog.Infof("Cleaning up test namespace: %s", testNamespace)
 	if err := kubeClient.CoreV1().Namespaces().Delete(ctx, testNamespace, metav1.DeleteOptions{}); err != nil {
-		t.Fatalf("Failed to delete namespace %s: %v", testNamespace, err)
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("Failed to delete namespace %s: %v", testNamespace, err)
+		}
+		// Don't fail the cleanup with Fatalf - just log and continue
+		// This allows retries to work properly
+		return
 	}
 	o.Eventually(func() bool {
 		_, err := kubeClient.CoreV1().Namespaces().Get(ctx, testNamespace, metav1.GetOptions{})


### PR DESCRIPTION
Hi Team,
PTAL on the PR. 

Failure log:
```
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_secondary-scheduler-operator/1398/pull-ci-openshift-secondary-scheduler-operator-main-e2e-aws-operator-serial-ote/2063936010365964288

Cases:
[Monitor:termination-message-policy][sig-arch] all containers in ns/openshift-secondary-scheduler-operator must have terminationMessagePolicy=FallbackToLogsOnError expand_more
[Monitor:required-scc-annotation-checker][sig-auth] all workloads in ns/openshift-secondary-scheduler-operator must set the 'openshift.io/required-scc' annotation expand_more
[sig-scheduling][Operator][Serial] SecondaryScheduler Operator when secondary scheduler is deployed should schedule a pod using the secondary scheduler expand_more
```

PR does:
- Add openshift.io/required-scc: restricted-v2 to all pod templates
- Add terminationMessagePolicy: FallbackToLogsOnError to all containers
- Fix e2e test pod image: kubernetes/pause -> registry.k8s.io/pause:3.10
- Fix e2e namespace cleanup to handle errors gracefully