### PR TITLE
fix(.tekton): use OCP 4.21 for DAST ephemeral cluster

### DIFF
--- a/.tekton/integration-tests/pipelines/secondary-scheduler-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/secondary-scheduler-operator-dast-pipeline-4-21.yaml
@@ -110,7 +110,7 @@ spec:
                   value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
             params:
               - name: prefix
-                value: "4.20."
+                value: "4.21."
           - name: create-cluster
             ref:
               resolver: git


### PR DESCRIPTION
## Summary

- Updates the DAST pipeline ephemeral cluster version from 4.20.x to 4.21.x
- OCP 4.20 clusters fail to reconcile ImageDigestMirrorSet in time, causing operator image pulls to fail against registry.redhat.io with "manifest unknown"
- Tested and verified on Konflux EaaS with OCP 4.21 (pipeline succeeds end-to-end)