### PR TITLE
[WIP-dummy] Fix HighlyAvailable topology defaults and add minimum replica validation

### DIFF
--- a/deploy/00_secondary-scheduler-operator.crd.yaml
+++ b/deploy/00_secondary-scheduler-operator.crd.yaml
@@ -99,7 +99,6 @@ spec:
                       If empty, defaults will be applied. The defaults are subject to change over time.
                     properties:
                       maxReplicas:
-                        default: 3
                         description: |-
                           maxReplicas defines the maximum number of replicas for the secondary scheduler.
                           In HA mode, the actual number of replicas is determined by the number of nodes
@@ -175,6 +174,8 @@ spec:
                 x-kubernetes-validations:
                 - message: highlyAvailableTopology can only be set when mode is HighlyAvailable
                   rule: self.mode == 'HighlyAvailable' || !has(self.highlyAvailableTopology)
+                - message: maxReplicas must be at least 3 for HighlyAvailable mode
+                  rule: self.mode != 'HighlyAvailable' || !has(self.highlyAvailableTopology) || !has(self.highlyAvailableTopology.maxReplicas) || self.highlyAvailableTopology.maxReplicas >= 3
               unsupportedConfigOverrides:
                 description: |-
                   unsupportedConfigOverrides overrides the final configuration that was computed by the operator.

--- a/manifests/secondary-scheduler-operator.crd.yaml
+++ b/manifests/secondary-scheduler-operator.crd.yaml
@@ -99,7 +99,6 @@ spec:
                       If empty, defaults will be applied. The defaults are subject to change over time.
                     properties:
                       maxReplicas:
-                        default: 3
                         description: |-
                           maxReplicas defines the maximum number of replicas for the secondary scheduler.
                           In HA mode, the actual number of replicas is determined by the number of nodes
@@ -175,6 +174,8 @@ spec:
                 x-kubernetes-validations:
                 - message: highlyAvailableTopology can only be set when mode is HighlyAvailable
                   rule: self.mode == 'HighlyAvailable' || !has(self.highlyAvailableTopology)
+                - message: maxReplicas must be at least 3 for HighlyAvailable mode
+                  rule: self.mode != 'HighlyAvailable' || !has(self.highlyAvailableTopology) || !has(self.highlyAvailableTopology.maxReplicas) || self.highlyAvailableTopology.maxReplicas >= 3
               unsupportedConfigOverrides:
                 description: |-
                   unsupportedConfigOverrides overrides the final configuration that was computed by the operator.

--- a/pkg/apis/secondaryscheduler/v1/defaults.go
+++ b/pkg/apis/secondaryscheduler/v1/defaults.go
@@ -1,0 +1,17 @@
+package v1
+
+// SetDefaults_SecondaryScheduler sets default values for SecondaryScheduler
+func SetDefaults_SecondaryScheduler(obj *SecondaryScheduler) {
+	SetDefaults_Topology(&obj.Spec.Topology)
+}
+
+// SetDefaults_Topology sets default values for Topology based on the mode
+func SetDefaults_Topology(obj *Topology) {
+	// When mode is HighlyAvailable and highlyAvailableTopology is not set,
+	// initialize it with default values
+	if obj.Mode == HighlyAvailableMode && obj.HighlyAvailableTopology == nil {
+		obj.HighlyAvailableTopology = &HighlyAvailableTopology{
+			MaxReplicas: 3,
+		}
+	}
+}

--- a/pkg/apis/secondaryscheduler/v1/defaults_test.go
+++ b/pkg/apis/secondaryscheduler/v1/defaults_test.go
@@ -1,0 +1,50 @@
+package v1
+
+import (
+	"testing"
+)
+
+func TestSetDefaults_Topology_HighlyAvailable(t *testing.T) {
+	topology := &Topology{
+		Mode: HighlyAvailableMode,
+	}
+
+	SetDefaults_Topology(topology)
+
+	if topology.HighlyAvailableTopology == nil {
+		t.Errorf("Expected HighlyAvailableTopology to be initialized, got nil")
+	}
+
+	if topology.HighlyAvailableTopology.MaxReplicas != 3 {
+		t.Errorf("Expected MaxReplicas to default to 3, got %d", topology.HighlyAvailableTopology.MaxReplicas)
+	}
+}
+
+func TestSetDefaults_Topology_SingleReplica(t *testing.T) {
+	topology := &Topology{
+		Mode: SingleReplicaMode,
+	}
+
+	SetDefaults_Topology(topology)
+
+	if topology.HighlyAvailableTopology != nil {
+		t.Errorf("Expected HighlyAvailableTopology to be nil for SingleReplica mode, got %+v", topology.HighlyAvailableTopology)
+	}
+}
+
+func TestSetDefaults_Topology_HighlyAvailable_WithExisting(t *testing.T) {
+	maxReplicas := uint32(5)
+	topology := &Topology{
+		Mode: HighlyAvailableMode,
+		HighlyAvailableTopology: &HighlyAvailableTopology{
+			MaxReplicas: maxReplicas,
+		},
+	}
+
+	SetDefaults_Topology(topology)
+
+	// Should not override existing values
+	if topology.HighlyAvailableTopology.MaxReplicas != maxReplicas {
+		t.Errorf("Expected MaxReplicas to remain %d, got %d", maxReplicas, topology.HighlyAvailableTopology.MaxReplicas)
+	}
+}

--- a/pkg/apis/secondaryscheduler/v1/register.go
+++ b/pkg/apis/secondaryscheduler/v1/register.go
@@ -16,12 +16,12 @@ var (
 	SchemeGroupVersion = schema.GroupVersion{Group: "operator.openshift.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, RegisterDefaults)
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
 func init() {
-	SchemeBuilder.Register(addKnownTypes)
+	SchemeBuilder.Register(addKnownTypes, RegisterDefaults)
 }
 
 // Resource takes an unqualified resource and returns a Group qualified GroupResource

--- a/pkg/apis/secondaryscheduler/v1/types.go
+++ b/pkg/apis/secondaryscheduler/v1/types.go
@@ -54,6 +54,7 @@ const (
 
 // Topology allows to configure the secondary schedulers to run in an HA mode
 // +kubebuilder:validation:XValidation:rule="self.mode == 'HighlyAvailable' || !has(self.highlyAvailableTopology)",message="highlyAvailableTopology can only be set when mode is HighlyAvailable"
+// +kubebuilder:validation:XValidation:rule="self.mode != 'HighlyAvailable' || !has(self.highlyAvailableTopology) || !has(self.highlyAvailableTopology.maxReplicas) || self.highlyAvailableTopology.maxReplicas >= 3",message="maxReplicas must be at least 3 for HighlyAvailable mode"
 type Topology struct {
 	// mode defines the topology mode for the secondary scheduler instances.
 	// If unspecified, mode defaults to SingleReplica. The default is subject to change over time.
@@ -83,7 +84,6 @@ type HighlyAvailableTopology struct {
 	// matching the nodeSelector, but will not exceed maxReplicas if specified.
 	// If unspecified, maxReplicas defaults to 3.
 	// The default is subject to change over time.
-	// +kubebuilder:default=3
 	// +kubebuilder:validation:Minimum=1
 	MaxReplicas uint32 `json:"maxReplicas,omitempty"`
 }

--- a/pkg/apis/secondaryscheduler/v1/zz_generated.defaults.go
+++ b/pkg/apis/secondaryscheduler/v1/zz_generated.defaults.go
@@ -27,5 +27,8 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&SecondaryScheduler{}, func(obj interface{}) {
+		SetDefaults_SecondaryScheduler(obj.(*SecondaryScheduler))
+	})
 	return nil
 }

--- a/test/e2e/bindata/assets/00_secondary-scheduler-operator.crd.yaml
+++ b/test/e2e/bindata/assets/00_secondary-scheduler-operator.crd.yaml
@@ -99,7 +99,6 @@ spec:
                       If empty, defaults will be applied. The defaults are subject to change over time.
                     properties:
                       maxReplicas:
-                        default: 3
                         description: |-
                           maxReplicas defines the maximum number of replicas for the secondary scheduler.
                           In HA mode, the actual number of replicas is determined by the number of nodes
@@ -175,6 +174,8 @@ spec:
                 x-kubernetes-validations:
                 - message: highlyAvailableTopology can only be set when mode is HighlyAvailable
                   rule: self.mode == 'HighlyAvailable' || !has(self.highlyAvailableTopology)
+                - message: maxReplicas must be at least 3 for HighlyAvailable mode
+                  rule: self.mode != 'HighlyAvailable' || !has(self.highlyAvailableTopology) || !has(self.highlyAvailableTopology.maxReplicas) || self.highlyAvailableTopology.maxReplicas >= 3
               unsupportedConfigOverrides:
                 description: |-
                   unsupportedConfigOverrides overrides the final configuration that was computed by the operator.


### PR DESCRIPTION
This commit addresses two issues in the SecondaryScheduler CRD:

1. Bug Fix: Remove automatic population of highlyAvailableTopology in SingleReplica mode
   - Previously, the CRD had 'default: 3' on maxReplicas field, which caused the entire highlyAvailableTopology object to be auto-populated even when mode: SingleReplica, triggering a validation error
   - Removed the default value from CRD to prevent auto-population
   - The controller already handles runtime defaults at target_config_reconciler.go:478

2. Enhancement: Add minimum replica validation for HighlyAvailable mode
   - Added CEL validation rule requiring maxReplicas >= 3 for HighlyAvailable mode
   - This ensures proper fault tolerance in HA configurations

3. Server-side defaults (optional enhancement):
   - Added defaults.go with conditional defaulting logic
   - When mode: HighlyAvailable and highlyAvailableTopology is nil, maxReplicas defaults to 3 (applies via kubectl/oc, not console form)
   - Registered defaults in scheme for API server integration

Changes:
- pkg/apis/secondaryscheduler/v1/types.go: Removed +kubebuilder:default=3, added validation
- pkg/apis/secondaryscheduler/v1/defaults.go: NEW - Conditional defaulting logic
- pkg/apis/secondaryscheduler/v1/defaults_test.go: NEW - Unit tests for defaults
- pkg/apis/secondaryscheduler/v1/register.go: Register defaults in scheme
- pkg/apis/secondaryscheduler/v1/zz_generated.defaults.go: Wire up defaults
- deploy/00_secondary-scheduler-operator.crd.yaml: Removed default, added validation
- manifests/secondary-scheduler-operator.crd.yaml: Removed default, added validation
- test/e2e/bindata/assets/00_secondary-scheduler-operator.crd.yaml: Removed default, added validation

Testing:
- SingleReplica mode: No highlyAvailableTopology auto-populated ✓
- HighlyAvailable mode with maxReplicas < 3: Validation error ✓
- HighlyAvailable mode with maxReplicas >= 3: Accepted ✓