### PR TITLE
CNTRLPLANE-3663: add llm agent and architecture context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# AI Agent Instructions for secondary-scheduler-operator
+
+## What This Repo Is
+
+This is an OpenShift operator that deploys custom Kubernetes schedulers built with the [scheduler plugin framework](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/). It allows users to run additional schedulers alongside the default OpenShift scheduler with customized scheduling policies and plugin configurations.
+
+## Repository Structure
+
+```
+secondary-scheduler-operator/
+├── cmd/
+│   ├── secondary-scheduler-operator/           # Main operator binary
+│   └── secondary-scheduler-operator-tests-ext/ # OTE test harness
+├── pkg/
+│   ├── operator/                               # Core operator logic
+│   │   ├── starter.go                          # Controller initialization
+│   │   ├── target_config_reconciler.go         # Main reconciliation controller
+│   │   ├── configobservation/                  # TLS config observer
+│   │   └── operatorclient/                     # Operator client wrapper
+│   ├── apis/secondaryscheduler/v1/             # API type definitions
+│   ├── generated/                              # Generated clientsets, informers, listers
+│   ├── cmd/operator/                           # Operator command setup
+│   ├── version/                                # Version information
+│   └── dependencymagnet/                       # Dependency imports for vendoring
+├── test/
+│   └── e2e/                                    # E2E test suites (serial and parallel)
+├── bindata/                                    # Embedded YAML assets for operand resources
+│   └── assets/secondary-scheduler/             # ServiceAccount, ClusterRoleBindings, Deployment, etc.
+├── deploy/                                     # Sample deployment manifests
+├── manifests/                                  # CRD and CSV definitions
+├── hack/                                       # Build and codegen scripts
+└── vendor/                                     # Go dependencies (managed by go mod)
+```
+
+## Build/Verify Workflow
+
+```bash
+make build               # Compile operator + test binaries (outputs to ./)
+make test-unit           # Unit tests (./pkg/... ./cmd/...)
+make test-e2e            # E2E tests via OTE harness (requires OpenShift cluster)
+                         # - Serial suite: openshift/secondary-scheduler-operator/operator/serial
+make verify              # Run all verification checks (gofmt, etc.)
+make generate            # Regenerate CRDs and clients (runs update-codegen-crds and generate-clients)
+make install-local       # Apply CRD, namespace, configmap, and CR to cluster
+make run-local           # Run operator locally against KUBECONFIG cluster
+```
+
+## Critical Rules
+
+1. **Do not edit generated files.** Files matching `zz_generated.*` under `pkg/generated/` and `pkg/apis/` are code-generated. Run `make generate-clients` to regenerate them.
+2. **Do not edit vendored files.** The `vendor/` directory is managed by `go mod tidy && go mod vendor`. Never hand-edit anything under `vendor/`.
+3. **CRD is owned by this repo.** The `SecondaryScheduler` CRD is defined here in `manifests/secondary-scheduler-operator.crd.yaml`. The types in `pkg/apis/secondaryscheduler/v1/types.go` embed `operatorv1.OperatorSpec/OperatorStatus` from `openshift/api`.
+4. **Bindata assets are embedded.** The YAML files in `bindata/assets/secondary-scheduler/` are embedded into the operator binary at build time. Changes require rebuilding the operator.
+5. **Use make build, not go build.** The Makefile uses `build-machinery-go` targets that handle codegen and vendoring correctly.
+
+## Key Patterns
+
+- **Single CR reconciliation**: The operator watches the `SecondaryScheduler` CR named `cluster` in the `openshift-secondary-scheduler-operator` namespace. All configuration comes from this singleton CR.
+- **Resource ownership**: All operand resources (Deployment, ServiceAccount, ClusterRoleBindings, Service, ServiceMonitor) are created with `OwnerReference` pointing to the SecondaryScheduler CR for garbage collection.
+- **Annotation-driven rollouts**: The Deployment's pod template is annotated with resource versions of ConfigMaps and other dependencies to trigger automatic rollouts when configuration changes.
+- **HA mode with dynamic replicas**: When `topology.mode=HighlyAvailable`, the operator counts nodes matching the `nodeSelector` and sets replicas accordingly, capped at `maxReplicas` (default 3). Only **one replica actively schedules** at a time due to leader election — the others are standby for high availability failover.
+
+## Important Constraints
+
+- **Namespace is fixed**: The operator expects the CR to exist in `openshift-secondary-scheduler-operator` namespace with name `cluster` (see `pkg/operator/operatorclient/interfaces.go:24-26`).
+- **ConfigMap must exist**: The CR's `spec.schedulerConfig` field must reference an existing ConfigMap containing a valid `KubeSchedulerConfiguration` under the key `config.yaml`.
+- **Leader election is enabled**: The scheduler runs with `--leader-elect=true`, so in HA mode only one replica actively schedules pods at a time. The other replicas are standby and take over if the leader fails.
+- **Pod anti-affinity is soft**: In HA mode, the operator configures `preferredDuringSchedulingIgnoredDuringExecution` pod anti-affinity to spread replicas across nodes, but it's not a hard requirement.
+
+## What NOT to Do
+
+- **Do not modify OWNERS or OWNERS_ALIASES files** without authorization.
+- **Do not change the operator namespace** (`openshift-secondary-scheduler-operator`) — it's hardcoded in many places and expected by the operand.
+- **Do not skip `make verify`** — CI will fail if linters or formatting checks fail.
+- **Do not run E2E tests on non-OpenShift clusters** — the tests expect OpenShift-specific resources (Routes for Prometheus access) and Prometheus Operator (ServiceMonitor CRD).
+- **Do not modify the scheduler image** — the operator deploys whatever image is specified in `spec.schedulerImage`. The operator itself doesn't build or manage scheduler images.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,185 @@
+# Architecture Overview
+
+## Scope
+
+This operator manages **custom secondary schedulers** for OpenShift/Kubernetes clusters. It reconciles the `SecondaryScheduler` CR and deploys a customized scheduler image (built with the scheduler plugin framework) alongside OpenShift's default scheduler. The operator handles RBAC, configuration mounting, High Availability topology, and observability (metrics via ServiceMonitor). TLS certificates for the metrics endpoint are automatically provisioned by OpenShift's service-ca-operator.
+
+## Controllers
+
+The operator runs **4 concurrent controllers** (all sharing informers and event handlers):
+
+1. **TargetConfigReconciler** (`pkg/operator/target_config_reconciler.go`): Main reconciliation loop that manages the scheduler Deployment and all supporting resources (ServiceAccount, ClusterRoleBindings, Service, Role, RoleBinding, ServiceMonitor).
+2. **ConfigObserver** (`pkg/operator/configobservation/configobservercontroller/`): Watches the cluster `APIServer` config for TLS settings (cipher suites, minTLSVersion) and syncs them to the SecondaryScheduler CR's `observedConfig`.
+3. **ResourceSyncController** (`library-go`): Syncs ConfigMaps and Secrets between namespaces if needed.
+4. **LogLevelController** (`library-go`): Adjusts operator logging based on the CR's `logLevel` field.
+
+All controllers use **informers** from `library-go`'s `KubeInformersForNamespaces` to watch resources efficiently.
+
+## Reconciliation Flow
+
+```text
+Event (SecondaryScheduler CR, ConfigMap, Deployment, etc.)
+  → Enqueue queueItem{kind: "secondaryscheduler"} or {kind: "configmap", name: "..."}
+    → sync(item)
+      ├── Get SecondaryScheduler CR (cluster/openshift-secondary-scheduler-operator)
+      ├── Skip reconciliation if item is ConfigMap and doesn't match schedulerConfig
+      ├── Collect resource versions for annotations:
+      │   ├── ConfigMap/<schedulerConfig> ResourceVersion
+      │   ├── Managed resources (ServiceAccount, ClusterRoleBindings, Service, etc.)
+      │   └── Store in specAnnotations map for Deployment pod template
+      ├── Resource management (in order):
+      │   ├── manageServiceAccount()
+      │   ├── manageKubeSchedulerClusterRoleBinding()
+      │   ├── manageVolumeSchedulerClusterRoleBinding()
+      │   ├── manageService()
+      │   ├── manageRole() / manageRoleBinding() (for prometheus access)
+      │   ├── manageOperandRole() / manageOperandRoleBinding()
+      │   ├── manageServiceMonitor()
+      │   └── manageDeployment() — applies all annotations and HA topology config
+      └── Update SecondaryScheduler status with Deployment generation
+```
+
+## Resource Generation
+
+The operator uses **embedded YAML templates** from `bindata/assets/secondary-scheduler/`:
+
+- **ServiceAccount** (`serviceaccount.yaml`): `secondary-scheduler` SA for the scheduler pods
+- **ClusterRoleBindings** (`clusterrolebinding-*.yaml`): Bind to `system:kube-scheduler` and `system:volume-scheduler` ClusterRoles
+- **Deployment** (`deployment.yaml`): Scheduler pod spec with placeholders `${IMAGE}` and `${CONFIGMAP}`
+- **Service** (`service.yaml`): Metrics service exposing port 10259
+- **ServiceMonitor** (`servicemonitor.yaml`): Prometheus scraping configuration
+- **Role/RoleBinding** (`role.yaml`, `rolebinding.yaml`): Grant prometheus access to scrape metrics
+- **OperandRole/OperandRoleBinding** (`operandrole.yaml`, `operandrolebinding.yaml`): Additional RBAC for the operand
+
+Each resource is loaded via `resourceread.*OrDie()`, modified in-memory (image substitution, ConfigMap name, OwnerReferences, etc.), and applied using `resourceapply.Apply*()` from `library-go`.
+
+### Deployment Customization
+
+The `manageDeployment()` function performs several key transformations:
+
+1. **Image substitution**: Replaces `${IMAGE}` with `spec.schedulerImage`
+2. **ConfigMap mounting**: Replaces `${CONFIGMAP}` volume source with `spec.schedulerConfig`
+3. **Log level args**: Appends `-v=<level>` based on `spec.logLevel` (Normal=2, Debug=4, Trace=6, TraceAll=8)
+4. **TLS configuration**: Parses `spec.observedConfig.Raw` for `servingInfo.cipherSuites` and `minTLSVersion`, appends as scheduler args
+5. **HA topology**:
+   - If `topology.mode=HighlyAvailable`:
+     - Count nodes matching `highlyAvailableTopology.nodeSelector`
+     - Set replicas to min(node_count, maxReplicas)
+     - Apply `nodeSelector` and `tolerations` to pod template
+6. **Annotation merging**: Merge `specAnnotations` (resource versions) into pod template to force rollouts on config changes
+
+## CRDs Reconciled
+
+- **`SecondaryScheduler`** (`secondaryschedulers.operator.openshift.io/v1`): Main CR defining scheduler configuration
+  - `spec.schedulerConfig`: ConfigMap name containing `KubeSchedulerConfiguration`
+  - `spec.schedulerImage`: Container image for the custom scheduler
+  - `spec.topology`: HA configuration (mode, nodeSelector, tolerations, maxReplicas)
+  - `spec.observedConfig`: TLS settings synced from cluster APIServer config
+  - `spec.logLevel`: Operator log verbosity (Normal, Debug, Trace, TraceAll)
+
+## High Availability Mode
+
+When `topology.mode: HighlyAvailable`:
+
+1. **Dynamic replica calculation**:
+   ```go
+   nodes := ListNodes(labelSelector: highlyAvailableTopology.nodeSelector)
+   replicas := min(len(nodes), maxReplicas)  // maxReplicas defaults to 3
+   ```
+
+2. **Pod anti-affinity** (soft, weight 100):
+   ```yaml
+   preferredDuringSchedulingIgnoredDuringExecution:
+     - weight: 100
+       podAffinityTerm:
+         labelSelector:
+           matchLabels:
+             app: secondary-scheduler
+         topologyKey: kubernetes.io/hostname
+   ```
+   This spreads replicas across nodes but allows multiple on the same node if needed.
+
+3. **Leader election**: The scheduler runs with `--leader-elect=true`, so only one replica actively schedules at a time. Other replicas are **standby** — they don't schedule pods, but are ready to take over if the active leader fails or becomes unreachable. This provides high availability without duplicate scheduling work.
+
+## Dependencies
+
+```text
+secondary-scheduler-operator
+├── depends on
+│   ├── openshift/api                (SecondaryScheduler CRD, APIServer, Infrastructure)
+│   ├── openshift/client-go          (generated clients for OpenShift APIs)
+│   ├── openshift/library-go         (controller framework, resourceapply, status helpers)
+│   ├── k8s.io/client-go             (informers, work queues, retry logic)
+│   └── prometheus-operator/apis     (ServiceMonitor CRD)
+│
+├── manages
+│   ├── Deployment                   (openshift-secondary-scheduler-operator/secondary-scheduler)
+│   ├── ServiceAccount + RBAC        (ClusterRoleBindings, Role, RoleBinding)
+│   ├── Service (metrics)
+│   ├── ServiceMonitor               (Prometheus scraping)
+│   └── Secret                       (TLS certificates via service-ca)
+│
+└── reads configuration from
+    ├── SecondaryScheduler CR        (cluster/openshift-secondary-scheduler-operator)
+    ├── ConfigMap                    (user-provided KubeSchedulerConfiguration)
+    └── APIServer CR                 (cluster TLS settings via configObserver)
+```
+
+## Design Decisions
+
+### Why single CR reconciliation?
+
+The operator expects exactly one CR named `cluster` in namespace `openshift-secondary-scheduler-operator`. This singleton pattern simplifies reconciliation logic and status tracking — there's no need to handle multiple scheduler deployments or namespaces.
+
+### Why embed YAML assets instead of generating programmatically?
+
+Embedding YAML templates makes it easier to review and version-control the exact manifests deployed by the operator. The templates use simple placeholder substitution (`${IMAGE}`, `${CONFIGMAP}`) rather than complex Go structs.
+
+### Why soft pod anti-affinity instead of hard?
+
+Hard anti-affinity (`requiredDuringSchedulingIgnoredDuringExecution`) would prevent scheduling if there aren't enough nodes. Soft anti-affinity allows the scheduler to run in constrained environments (single-node, or fewer nodes than replicas) while still spreading pods when possible.
+
+### Why annotation-driven rollouts?
+
+Embedding resource versions of ConfigMaps and other dependencies in the Deployment's pod template annotations forces Kubernetes to perform a rolling update whenever configuration changes. This ensures the scheduler always runs with the latest config without manual restarts.
+
+### Why ConfigObserver for TLS settings?
+
+The cluster APIServer CR defines global TLS policy. By observing and syncing these settings to the SecondaryScheduler CR's `observedConfig`, the operator ensures the scheduler respects cluster-wide security policies without requiring manual configuration.
+
+## Testing
+
+- **Unit tests**: `pkg/operator/*_test.go` (reconciler logic, HA replica calculation)
+- **E2E tests**: `test/e2e/` (full operator lifecycle on OpenShift clusters)
+  - **Serial suite** (`openshift/secondary-scheduler-operator/operator/serial`): Operator deployment, scheduling, HA mode, observability
+    - Tests run with `-c 1` (serial) to avoid conflicts
+    - Uses OTE framework ([OpenShift Tests Extension](https://github.com/openshift-eng/openshift-tests-extension))
+  - **Framework**: `test/e2e/helpers.go` provides client constructors, Prometheus query helpers, etc.
+
+### E2E Test Flow
+
+1. `setupOperator()`: Apply CRD, namespace, RBAC, operator Deployment, ConfigMap, and SecondaryScheduler CR
+2. Wait for operator pod to be Running
+3. Test scheduling: Create a pod with `schedulerName: secondary-scheduler`, verify it gets assigned to a node
+4. Test observability: Verify Service, ServiceMonitor exist and Prometheus scrapes metrics
+5. Test HA mode: Verify replica count matches node count (capped at maxReplicas), verify anti-affinity
+
+## Observability
+
+- **Metrics**: Exposed on port 10259 (HTTPS) via the scheduler's built-in metrics endpoint
+- **ServiceMonitor**: Configures Prometheus to scrape `scheduler_*` metrics from the secondary-scheduler pods
+- **Prometheus RBAC**: The operator creates a Role/RoleBinding to allow prometheus-k8s ServiceAccount to read endpoints/services/pods in the operator namespace
+
+## Configuration Observer
+
+The `ConfigObserver` controller watches:
+
+- **APIServer CR** (`config.openshift.io/v1`): Global cluster API server configuration
+  - Extracts `spec.tlsSecurityProfile.cipherSuites` and `spec.tlsSecurityProfile.minTLSVersion`
+  - Writes them to `SecondaryScheduler.spec.observedConfig.servingInfo` as unstructured JSON
+
+The `TargetConfigReconciler` then reads these values and appends them as scheduler command-line args:
+```bash
+--tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,...
+--tls-min-version=VersionTLS12
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,148 @@
+# Contributing to Secondary Scheduler Operator
+
+## Getting Started
+
+This operator deploys custom Kubernetes schedulers built with the [scheduler plugin framework](https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/) on OpenShift clusters.
+
+**New contributors**: Start by reading [AGENTS.md](./AGENTS.md) for a comprehensive overview of the repository structure, architecture, and development patterns.
+
+## Development Setup
+
+### Prerequisites
+
+- Go 1.24+ (check `go.mod` for current version)
+- Access to an OpenShift cluster (for testing)
+- `oc` CLI tool
+- `podman` or `docker` (for building images)
+
+### Build and Run Locally
+
+```bash
+# Build the operator binary
+make build
+
+# Install CRD and sample resources to your cluster
+make install-local
+
+# Run the operator locally (points to cluster via KUBECONFIG)
+make run-local
+```
+
+### Running Tests
+
+```bash
+# Run unit tests
+make test-unit
+
+# Run E2E tests (requires OpenShift cluster)
+make test-e2e
+
+# Run verification checks (gofmt, dependencies, etc.)
+make verify
+```
+
+## Making Changes
+
+### Code Generation
+
+If you modify API types in `pkg/apis/secondaryscheduler/v1/types.go`:
+
+```bash
+# Regenerate clientsets, informers, and listers
+make generate-clients
+```
+
+### Development Workflow
+
+1. **Create a branch** from `main`
+2. **Make your changes**
+3. **Run tests**: `make test-unit && make verify`
+4. **Test locally**: `make build && make run-local`
+5. **Commit your changes** with a clear commit message
+6. **Push and open a Pull Request**
+
+### Commit Message Guidelines
+
+Follow conventional commit style:
+
+```
+<type>: <short summary>
+
+<optional body with details>
+```
+
+Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `ci`
+
+Example:
+```
+feat: add nodeSelector support for HA topology
+
+Allow users to target specific nodes for secondary scheduler
+replicas in HighlyAvailable mode by specifying nodeSelector
+in the topology configuration.
+
+Fixes #123
+```
+
+## What NOT to Do
+
+- **Do not edit generated files** (`zz_generated.*`, files under `pkg/generated/`)
+- **Do not edit vendored files** (managed by `go mod`)
+- **Do not modify OWNERS or OWNERS_ALIASES** without approval
+- **Do not skip `make verify`** - CI will reject PRs that fail verification
+
+## Pull Request Process
+
+1. **Ensure all tests pass** locally before opening a PR
+2. **Update documentation** if you're adding features or changing behavior
+3. **Keep PRs focused** - one feature or fix per PR
+4. **Respond to review feedback** promptly
+
+### PR Checklist
+
+- [ ] Tests pass (`make test-unit && make verify`)
+- [ ] Code follows existing patterns and conventions
+- [ ] Documentation updated (README.md, AGENTS.md, or comments)
+- [ ] Commit messages are clear and follow guidelines
+- [ ] PR description explains what and why, not just what
+
+## Code Style
+
+- Follow standard Go conventions (effective Go, Go proverbs)
+- Run `gofmt` (enforced by `make verify`)
+- Keep functions focused and testable
+- Add comments for non-obvious logic (why, not what)
+
+## Testing Guidelines
+
+- **Unit tests**: Test individual functions and reconciliation logic
+- **E2E tests**: Test full operator lifecycle on OpenShift
+  - Use the OTE framework (OpenShift Tests Extension)
+  - Tests must be idempotent and clean up resources
+  - Mark disruptive tests with `[Serial]` tag
+
+## Architecture and Technical Details
+
+For deeper understanding of the operator's architecture:
+
+- [AGENTS.md](./AGENTS.md) - Repository structure, build workflow, patterns
+- [ARCHITECTURE.md](./ARCHITECTURE.md) - Controllers, reconciliation flow, design decisions
+- [README.md](./README.md) - User-facing documentation and deployment
+
+## Getting Help
+
+- **Questions about contributing?** Open a discussion or issue
+- **Found a bug?** Open an issue with reproduction steps
+- **Have a feature idea?** Open an issue to discuss before implementing
+- **Need architecture clarification?** Check ARCHITECTURE.md or ask in an issue
+
+## Community Guidelines
+
+- Be respectful and constructive in all interactions
+- Assume good intent from other contributors
+- Help newcomers get started
+- Review others' PRs when you can
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0 (see [LICENSE](./LICENSE)).


### PR DESCRIPTION
add documentation files to help llm agents and developers to understand this operator's architecture.

files added:
- AGENTS.md: llm agent instructions with repository structure.
- ARCHITECTURE.md: more in depth architecture overview.
- CLAUDE.md: just points to AGENTS.md
- CONTRIBUTING.md: adds some basic guidance on how to contribute.