### PR TITLE
CNTRLPLANE-3866: Add NetworkPolicy RBAC to secondary scheduler operat…

### DIFF
--- a/deploy/02_clusterrole.yaml
+++ b/deploy/02_clusterrole.yaml
@@ -100,3 +100,15 @@ rules:
       - create
       - update
       - patch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -224,6 +224,18 @@ spec:
                 - create
                 - update
                 - patch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
       permissions:
         - serviceAccountName: secondary-scheduler-operator
           rules:

--- a/test/e2e/bindata/assets/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/test/e2e/bindata/assets/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -225,6 +225,18 @@ spec:
           - create
           - update
           - patch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
       permissions:
       - serviceAccountName: secondary-scheduler-operator
         rules:


### PR DESCRIPTION
Hi Team,

PTAL.

PR about: Add networking.k8s.io/networkpolicies permissions (create, delete, update, patch, watch, list, get) to the operator's clusterPermissions in the CSV. This satisfies the Conforma policy olm.required_network_policy_rbac_for_operands for OCP 5.0 compliance.

// Without this PR fix we receive warning as,
```
[Warning] olm.required_network_policy_rbac_for_operands
  ImageRef: registry.redhat.io/openshift-secondary-scheduler-operator/secondary-scheduler-operator-bundle@sha256:5af2dc9f02c02b5f508b016c156f44515d96976c2804172d31b0b0ce2b9b7f56
  Reason: Operator "openshift-secondary-scheduler-operator" version "1.6.0" is missing required NetworkPolicy RBAC
  (networking.k8s.io/networkpolicies with create, delete, and update/patch)
  Title: NetworkPolicy RBAC present in OLM bundle
  Description: Operators are required to manage the network policies of their operands. This rule verifies that operator bundles
  request sufficient RBAC permissions to manage NetworkPolicy lifecycle (create, delete, and update/patch) for
  networking.k8s.io/networkpolicies in their ClusterServiceVersion. Bundles whose operator name and major.minor version are listed
  in the `operator_network_policy_rbac_exceptions` rule data key are exempt from this requirement.
  Solution: Add a rule granting create, delete, and update/patch on networking.k8s.io/networkpolicies to the ClusterServiceVersion
  clusterPermissions or permissions, or add the operator name and its major.minor version to the
  operator_network_policy_rbac_exceptions rule data key.
```

// With PR fix did not observe network rbac related warning
```
ec validate image \
    --image quay.io/redhat-user-workloads/crt-nshift-secondary-tenant/secondary-scheduler-operator-bundle-main@sha256:9368da56eb1fd051e1bd07d6403c27dcbb63387dc57953c61bdc34932dddedfa \
    --policy '{"sources":[{"policy":["oci::quay.io/enterprise-contract/ec-release-policy:latest"]}]}' \
    --ignore-rekor \
    --skip-image-sig-check \
    --skip-att-sig-check \
    --certificate-identity-regexp '.*' \
    --certificate-oidc-issuer-regexp '.*' \
    --output text \
    --strict false \
    --info

Result: FAILURE
Violations: 16, Warnings: 15, Successes: 146
Component: Unnamed
ImageRef: quay.io/redhat-user-workloads/crt-nshift-secondary-tenant/secondary-scheduler-operator-bundle-main@sha256:9368da56eb1fd051e1bd07d6403c27dcbb63387dc57953c61bdc34932dddedfa

✕ [Violation] trusted_task.data
  ImageRef: quay.io/redhat-user-workloads/crt-nshift-secondary-tenant/secondary-scheduler-operator-bundle-main@sha256:9368da56eb1fd051e1bd07d6403c27dcbb63387dc57953c61bdc34932dddedfa
  Reason: Missing required trusted_tasks data
  Title: Task tracking data was provided
  Description: Confirm the `trusted_tasks` rule data was provided, since it's required by the policy rules in this package. To
  exclude this rule add "trusted_task.data" to the `exclude` section of the policy configuration.
  Solution: Create a, or use an existing, trusted tasks list as a data source.

› [Warning] test.no_test_warnings
  ImageRef: quay.io/redhat-user-workloads/crt-nshift-secondary-tenant/secondary-scheduler-operator-bundle-main@sha256:9368da56eb1fd051e1bd07d6403c27dcbb63387dc57953c61bdc34932dddedfa
  Reason: The Task "deprecated-image-check" from the build Pipeline reports a test contains warnings
  Term: deprecated-image-check
  Title: No tests produced warnings
  Description: Produce a warning if any tests have their result set to "WARNING". The result type is configurable by the
  "warned_tests_results" key in the rule data.
  Solution: There is a task with result 'TEST_OUTPUT' that returned a result of 'WARNING'. You can find which test resulted in
  'WARNING' by examining the 'result' key in the 'TEST_OUTPUT'. More information about the test should be available in the logs
  for the build Pipeline.
```

/assign @ingvagabund @YamunadeviShanmugam

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the operator’s ability to manage Kubernetes NetworkPolicy resources.
  * Expanded RBAC permissions to support full lifecycle access to NetworkPolicies, including create, view, update, monitor, and delete operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->