### PR TITLE
CNTRLPLANE-3878: chore: prep 1.6.1. release

### DIFF
--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   # The version value is substituted by the ART pipeline
-  name: secondaryscheduleroperator.v1.6.0
+  name: secondaryscheduleroperator.v1.6.1
   namespace: openshift-secondary-scheduler-operator
   labels:
     operatorframework.io/arch.amd64: supported
@@ -27,7 +27,7 @@ metadata:
       ]
     certified: "false"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/secondary-scheduler-rhel9-operator:latest
-    createdAt: "2026-04-22"
+    createdAt: "2026-08-16"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -38,7 +38,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    olm.skipRange: ">=1.5.0 <1.6.0"
+    olm.skipRange: ">=1.5.0 <1.6.1"
     description: Runs a secondary scheduler in an OpenShift cluster.
     repository: https://github.com/openshift/secondary-scheduler-operator
     support: Red Hat, Inc.
@@ -68,6 +68,7 @@ spec:
     - secondaryscheduleroperator.v1.5.4
     - secondaryscheduleroperator.v1.5.5
     - secondaryscheduleroperator.v1.5.6
+    - secondaryscheduleroperator.v1.6.0
   customresourcedefinitions:
     owned:
       - displayName: Secondary Scheduler
@@ -96,7 +97,7 @@ spec:
   provider:
     name: Red Hat, Inc.
   maturity: beta
-  version: 1.6.0
+  version: 1.6.1
   relatedImages:
     - name: secondary-scheduler-operator
       image: registry-proxy.engineering.redhat.com/rh-osbs/secondary-scheduler-rhel9-operator:latest
@@ -112,7 +113,7 @@ spec:
   minKubeVersion: 1.35.0
   labels:
     olm-owner-enterprise-app: secondary-scheduler-operator
-    olm-status-descriptors: secondary-scheduler-operator.v1.6.0
+    olm-status-descriptors: secondary-scheduler-operator.v1.6.1
   installModes:
     - supported: true
       type: OwnNamespace


### PR DESCRIPTION
ssia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Cluster Secondary Scheduler Operator release metadata to version 1.6.1.
  * Added version 1.6.0 to the skipped release list for upgrade compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->