### PR TITLE
CNTRLPLANE-4140: Add network policies for secondary scheduler operand of OSSO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,8 @@ generate-clients:
 install-local:
 	oc apply -f deploy/00_secondary-scheduler-operator.crd.yaml
 	oc apply -f deploy/01_namespace.yaml
+	oc apply -f deploy/08_networkpolicy-default-deny.yaml
+	oc apply -f deploy/09_networkpolicy-allow.yaml
 	oc apply -f deploy/06_configmap.yaml
 	oc apply -f deploy/07_secondary-scheduler-operator.cr.yaml
 

--- a/bindata/assets/secondary-scheduler/networkpolicy-operand-allow.yaml
+++ b/bindata/assets/secondary-scheduler/networkpolicy-operand-allow.yaml
@@ -1,0 +1,30 @@
+# Allow all egress and metrics/health ingress for the secondary-scheduler operand pod.
+#
+# Egress is needed for:
+# - DNS resolution via openshift-dns
+# - Kubernetes API server communication (pod/node watches, bindings, leader election)
+#
+# Ingress is needed for:
+# - Prometheus metrics scraping on port 10259
+# - Kubelet health/readiness probes on port 10259
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-egress-and-metrics-ingress-operand
+  namespace: openshift-secondary-scheduler-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector:
+    matchLabels:
+      app: secondary-scheduler
+  egress:
+  - {}
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 10259
+  policyTypes:
+  - Ingress
+  - Egress

--- a/bindata/assets/secondary-scheduler/networkpolicy-operand-default-deny.yaml
+++ b/bindata/assets/secondary-scheduler/networkpolicy-operand-default-deny.yaml
@@ -1,0 +1,21 @@
+# Default-deny policy for all pods in the operand namespace.
+# This policy selects all pods and enables default-deny for both
+# ingress and egress by specifying policyTypes without any allow rules.
+#
+# Managed by the operator reconciler so it self-heals if deleted.
+# The corresponding allow policy (networkpolicy-operand-allow.yaml)
+# is applied first so traffic is never blocked during the window
+# between sequential resource applies.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openshift-secondary-scheduler-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/deploy/08_networkpolicy-default-deny.yaml
+++ b/deploy/08_networkpolicy-default-deny.yaml
@@ -1,0 +1,24 @@
+# Default-deny policy for the openshift-secondary-scheduler-operator namespace.
+# This policy selects all pods in the namespace and enables default-deny for both
+# ingress and egress by specifying policyTypes without any allow rules.
+#
+# NetworkPolicies are additive (use OR logic):
+# - This policy enables default-deny for all pods
+# - Subsequent policies add specific allow rules
+# - If any policy allows traffic, that traffic is permitted
+# - Policies cannot override or block traffic allowed by other policies
+#
+# Without this policy, all pods would have unrestricted network access (allow-all).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openshift-secondary-scheduler-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/deploy/09_networkpolicy-allow.yaml
+++ b/deploy/09_networkpolicy-allow.yaml
@@ -1,0 +1,30 @@
+# Allow all egress and metrics ingress for the secondary-scheduler-operator pod.
+#
+# Egress is needed for:
+# - DNS resolution via openshift-dns
+# - Kubernetes API server communication (address varies by cluster configuration)
+# - Creating and managing operand resources across namespaces
+#
+# Ingress is needed for:
+# - Prometheus metrics scraping on port 60000
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-egress-and-metrics-ingress
+  namespace: openshift-secondary-scheduler-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector:
+    matchLabels:
+      name: secondary-scheduler-operator
+  egress:
+  - {}
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 60000
+  policyTypes:
+  - Ingress
+  - Egress

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -188,6 +188,16 @@ func (c TargetConfigReconciler) sync(item queueItem) error {
 			annotationKey: "servicemonitors/secondary-scheduler",
 			manageFunc:    c.manageServiceMonitor,
 		},
+		// Network policies: apply allow rules before default-deny so that
+		// traffic is never blocked during the window between sequential applies.
+		{
+			annotationKey: "networkpolicies/operand-allow",
+			manageFunc:    c.manageNetworkPolicy,
+		},
+		{
+			annotationKey: "networkpolicies/default-deny",
+			manageFunc:    c.manageDefaultDenyNetworkPolicy,
+		},
 	}
 
 	for _, mr := range managedResources {
@@ -366,6 +376,40 @@ func (c *TargetConfigReconciler) manageServiceMonitor(secondaryScheduler *second
 	controller.EnsureOwnerRef(required, ownerReference)
 
 	return resourceapply.ApplyKnownUnstructured(c.ctx, c.dynamicClient, c.eventRecorder, required)
+}
+
+func (c *TargetConfigReconciler) manageNetworkPolicy(secondaryScheduler *secondaryschedulersv1.SecondaryScheduler) (metav1.Object, bool, error) {
+	required := resourceread.ReadNetworkPolicyV1OrDie(bindata.MustAsset("assets/secondary-scheduler/networkpolicy-operand-allow.yaml"))
+	required.Namespace = secondaryScheduler.Namespace
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "SecondaryScheduler",
+		Name:       secondaryScheduler.Name,
+		UID:        secondaryScheduler.UID,
+	}
+	required.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
+
+	return resourceapply.ApplyNetworkPolicy(c.ctx, c.kubeClient.NetworkingV1(), c.eventRecorder, required, resourceapply.NewResourceCache())
+}
+
+func (c *TargetConfigReconciler) manageDefaultDenyNetworkPolicy(secondaryScheduler *secondaryschedulersv1.SecondaryScheduler) (metav1.Object, bool, error) {
+	required := resourceread.ReadNetworkPolicyV1OrDie(bindata.MustAsset("assets/secondary-scheduler/networkpolicy-operand-default-deny.yaml"))
+	required.Namespace = secondaryScheduler.Namespace
+	ownerReference := metav1.OwnerReference{
+		APIVersion: "operator.openshift.io/v1",
+		Kind:       "SecondaryScheduler",
+		Name:       secondaryScheduler.Name,
+		UID:        secondaryScheduler.UID,
+	}
+	required.OwnerReferences = []metav1.OwnerReference{
+		ownerReference,
+	}
+	controller.EnsureOwnerRef(required, ownerReference)
+
+	return resourceapply.ApplyNetworkPolicy(c.ctx, c.kubeClient.NetworkingV1(), c.eventRecorder, required, resourceapply.NewResourceCache())
 }
 
 func (c *TargetConfigReconciler) manageDeployment(secondaryScheduler *secondaryschedulersv1.SecondaryScheduler, specAnnotations map[string]string) (*appsv1.Deployment, bool, error) {

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -27,6 +27,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,6 +166,9 @@ func setupFakeClients(t *testing.T, apiServer *configv1.APIServer, secondarySche
 	}
 	if err := rbacv1.AddToScheme(scheme); err != nil {
 		t.Fatalf("Failed to add rbacv1 to scheme: %v", err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to add networkingv1 to scheme: %v", err)
 	}
 	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
 
@@ -1087,6 +1091,52 @@ func TestManageResources(t *testing.T) {
 			},
 		},
 		{
+			resourceType: "NetworkPolicy",
+			resourceName: "allow-all-egress-and-metrics-ingress-operand",
+			manageFunc:   (*TargetConfigReconciler).manageNetworkPolicy,
+			getResource: func(ctx context.Context, setup *testSetup, name string) (metav1.Object, error) {
+				return setup.kubeClient.NetworkingV1().NetworkPolicies(operatorclient.OperatorNamespace).Get(ctx, name, metav1.GetOptions{})
+			},
+			updateResource: func(ctx context.Context, setup *testSetup, obj metav1.Object) error {
+				_, err := setup.kubeClient.NetworkingV1().NetworkPolicies(operatorclient.OperatorNamespace).Update(ctx, obj.(*networkingv1.NetworkPolicy), metav1.UpdateOptions{})
+				return err
+			},
+			modifyResource: func(t *testing.T, obj metav1.Object) {
+				np := obj.(*networkingv1.NetworkPolicy)
+				np.Spec.PodSelector.MatchLabels["app"] = "wrong-app"
+			},
+			verifyRestore: func(t *testing.T, obj metav1.Object) {
+				np := obj.(*networkingv1.NetworkPolicy)
+				app := np.Spec.PodSelector.MatchLabels["app"]
+				if app != "secondary-scheduler" {
+					t.Errorf("Expected podSelector app to be restored to %q, got %q", "secondary-scheduler", app)
+				}
+			},
+		},
+		{
+			resourceType: "NetworkPolicy",
+			resourceName: "default-deny",
+			manageFunc:   (*TargetConfigReconciler).manageDefaultDenyNetworkPolicy,
+			getResource: func(ctx context.Context, setup *testSetup, name string) (metav1.Object, error) {
+				return setup.kubeClient.NetworkingV1().NetworkPolicies(operatorclient.OperatorNamespace).Get(ctx, name, metav1.GetOptions{})
+			},
+			updateResource: func(ctx context.Context, setup *testSetup, obj metav1.Object) error {
+				_, err := setup.kubeClient.NetworkingV1().NetworkPolicies(operatorclient.OperatorNamespace).Update(ctx, obj.(*networkingv1.NetworkPolicy), metav1.UpdateOptions{})
+				return err
+			},
+			modifyResource: func(t *testing.T, obj metav1.Object) {
+				np := obj.(*networkingv1.NetworkPolicy)
+				np.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
+			},
+			verifyRestore: func(t *testing.T, obj metav1.Object) {
+				np := obj.(*networkingv1.NetworkPolicy)
+				expected := []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}
+				if diff := cmp.Diff(expected, np.Spec.PolicyTypes); diff != "" {
+					t.Errorf("Expected policyTypes to be restored, diff (-want +got):\n%s", diff)
+				}
+			},
+		},
+		{
 			resourceType:        "ClusterRoleBinding",
 			resourceName:        volumeSchedulerClusterRoleBindingName,
 			skipNamespaceVerify: true,
@@ -1380,6 +1430,8 @@ func TestSync(t *testing.T) {
 					"roles/secondary-scheduler-operand",
 					"rolebindings/secondary-scheduler-operand",
 					"servicemonitors/secondary-scheduler",
+					"networkpolicies/operand-allow",
+					"networkpolicies/default-deny",
 				}
 
 				for _, key := range expectedAnnotations {
@@ -1494,7 +1546,7 @@ func TestSyncResourceVersionAnnotations(t *testing.T) {
 			// Add reactors to set ResourceVersions when resources are created
 			if tc.resourceVersion != "" {
 				fakeClient := setup.kubeClient.(*kubefake.Clientset)
-				for _, resource := range []string{"serviceaccounts", "clusterrolebindings", "services", "roles", "rolebindings"} {
+				for _, resource := range []string{"serviceaccounts", "clusterrolebindings", "services", "roles", "rolebindings", "networkpolicies"} {
 					fakeClient.PrependReactor("create", resource, func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 						action.(kubetesting.CreateAction).GetObject().(metav1.Object).SetResourceVersion(tc.resourceVersion)
 						return false, nil, nil
@@ -1549,6 +1601,8 @@ func TestSyncResourceVersionAnnotations(t *testing.T) {
 				"roles/secondary-scheduler-operand":        tc.resourceVersion,
 				"rolebindings/secondary-scheduler-operand": tc.resourceVersion,
 				"servicemonitors/secondary-scheduler":      tc.resourceVersion,
+				"networkpolicies/operand-allow":      tc.resourceVersion,
+				"networkpolicies/default-deny":       tc.resourceVersion,
 			}
 
 			for key, expectedValue := range expectedAnnotations {


### PR DESCRIPTION
Adds NetworkPolicy resources for secondary scheduler operand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added default-deny network policies for the secondary-scheduler workloads.
  - Added controlled network access for metrics scraping and required outbound traffic.
  - Network policies are automatically installed and maintained during deployment and reconciliation.
  - Added support annotations for highly available and single-node environments.

- **Bug Fixes**
  - Improved restoration and consistency of network policies during synchronization and resource updates.
  - Updated permissions so network policies are managed within the operator namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->