### PR TITLE
OCPBUGS-113708: Fix operator metrics port and observability

### DIFF
--- a/deploy/05_deployment.yaml
+++ b/deploy/05_deployment.yaml
@@ -29,8 +29,26 @@ spec:
           image: quay.io/openshift/secondary-scheduler-operator:4.17
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
-          - containerPort: 60000
-            name: metrics
+          - containerPort: 8443
+            name: https
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: /healthz
+            initialDelaySeconds: 45
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: /healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
           command:
           - secondary-scheduler-operator
           args:
@@ -46,8 +64,15 @@ spec:
           volumeMounts:
           - name: tmp
             mountPath: "/tmp"
+          - name: serving-cert
+            mountPath: /var/run/secrets/serving-cert
+            readOnly: true
       serviceAccountName: secondary-scheduler-operator
       serviceAccount: secondary-scheduler-operator
       volumes:
       - name: tmp
         emptyDir: {}
+      - name: serving-cert
+        secret:
+          secretName: secondary-scheduler-operator-serving-cert
+          optional: true

--- a/deploy/08_service.yaml
+++ b/deploy/08_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: secondary-scheduler-operator-metrics
+  namespace: openshift-secondary-scheduler-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: secondary-scheduler-operator-serving-cert
+  labels:
+    name: secondary-scheduler-operator
+spec:
+  selector:
+    name: secondary-scheduler-operator
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+      protocol: TCP

--- a/deploy/09_servicemonitor.yaml
+++ b/deploy/09_servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: secondary-scheduler-operator
+  namespace: openshift-secondary-scheduler-operator
+spec:
+  selector:
+    matchLabels:
+      name: secondary-scheduler-operator
+  endpoints:
+    - port: https
+      scheme: https
+      interval: 30s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: secondary-scheduler-operator-metrics.openshift-secondary-scheduler-operator.svc

--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -284,8 +284,22 @@ spec:
                         memory: 50Mi
                         cpu: 10m
                     ports:
-                      - containerPort: 60000
-                        name: metrics
+                      - containerPort: 8443
+                        name: https
+                    livenessProbe:
+                      httpGet:
+                        scheme: HTTPS
+                        port: 8443
+                        path: /healthz
+                      initialDelaySeconds: 45
+                      timeoutSeconds: 10
+                    readinessProbe:
+                      httpGet:
+                        scheme: HTTPS
+                        port: 8443
+                        path: /healthz
+                      initialDelaySeconds: 10
+                      timeoutSeconds: 10
                     command:
                       - secondary-scheduler-operator
                     args:
@@ -301,9 +315,16 @@ spec:
                     volumeMounts:
                       - name: tmp
                         mountPath: "/tmp"
+                      - name: serving-cert
+                        mountPath: /var/run/secrets/serving-cert
+                        readOnly: true
                 serviceAccountName: secondary-scheduler-operator
                 serviceAccount: openshift-secondary-scheduler-operator
                 volumes:
                   - name: tmp
                     emptyDir: {}
+                  - name: serving-cert
+                    secret:
+                      secretName: secondary-scheduler-operator-serving-cert
+                      optional: true
     strategy: deployment

--- a/manifests/operator-service.yaml
+++ b/manifests/operator-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: secondary-scheduler-operator-metrics
+  namespace: openshift-secondary-scheduler-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: secondary-scheduler-operator-serving-cert
+  labels:
+    name: secondary-scheduler-operator
+spec:
+  selector:
+    name: secondary-scheduler-operator
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 8443
+      protocol: TCP

--- a/manifests/operator-servicemonitor.yaml
+++ b/manifests/operator-servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: secondary-scheduler-operator
+  namespace: openshift-secondary-scheduler-operator
+spec:
+  selector:
+    matchLabels:
+      name: secondary-scheduler-operator
+  endpoints:
+    - port: https
+      scheme: https
+      interval: 30s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: secondary-scheduler-operator-metrics.openshift-secondary-scheduler-operator.svc

--- a/test/e2e/bindata/assets/05_deployment.yaml
+++ b/test/e2e/bindata/assets/05_deployment.yaml
@@ -29,8 +29,26 @@ spec:
           image: # Value set in e2e
           terminationMessagePolicy: FallbackToLogsOnError
           ports:
-          - containerPort: 60000
-            name: metrics
+          - containerPort: 8443
+            name: https
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: /healthz
+            initialDelaySeconds: 45
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+              path: /healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
           command:
           - secondary-scheduler-operator
           args:
@@ -46,8 +64,15 @@ spec:
           volumeMounts:
           - name: tmp
             mountPath: "/tmp"
+          - name: serving-cert
+            mountPath: /var/run/secrets/serving-cert
+            readOnly: true
       serviceAccountName: secondary-scheduler-operator
       serviceAccount: secondary-scheduler-operator
       volumes:
       - name: tmp
         emptyDir: {}
+      - name: serving-cert
+        secret:
+          secretName: secondary-scheduler-operator-serving-cert
+          optional: true

--- a/test/e2e/bindata/assets/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/test/e2e/bindata/assets/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -284,8 +284,22 @@ spec:
                         memory: 50Mi
                         cpu: 10m
                     ports:
-                      - containerPort: 60000
-                        name: metrics
+                      - containerPort: 8443
+                        name: https
+                    livenessProbe:
+                      httpGet:
+                        scheme: HTTPS
+                        port: 8443
+                        path: /healthz
+                      initialDelaySeconds: 45
+                      timeoutSeconds: 10
+                    readinessProbe:
+                      httpGet:
+                        scheme: HTTPS
+                        port: 8443
+                        path: /healthz
+                      initialDelaySeconds: 10
+                      timeoutSeconds: 10
                     command:
                       - secondary-scheduler-operator
                     args:
@@ -301,9 +315,16 @@ spec:
                     volumeMounts:
                       - name: tmp
                         mountPath: "/tmp"
+                      - name: serving-cert
+                        mountPath: /var/run/secrets/serving-cert
+                        readOnly: true
                 serviceAccountName: secondary-scheduler-operator
                 serviceAccount: openshift-secondary-scheduler-operator
                 volumes:
                   - name: tmp
                     emptyDir: {}
+                  - name: serving-cert
+                    secret:
+                      secretName: secondary-scheduler-operator-serving-cert
+                      optional: true
     strategy: deployment


### PR DESCRIPTION
Hi Team,

PTAL on the PR. 

Summary
The operator deployment declared containerPort 60000 but the operator
binary (via library-go) actually listens on port 8443. This fixes the
port declaration and adds proper observability infrastructure:

- Fix containerPort from 60000 to 8443 (named https) across all manifests
- Add leading slash to healthz probe paths (/healthz)
- Add resource requests (cpu: 10m, memory: 50Mi)
- Add serving-cert secret volume mount for proper TLS
- Add Service with serving-cert annotation for OpenShift service CA
- Add ServiceMonitor with proper CA validation and bearer token auth
- Replace insecureSkipVerify with caFile + serverName in ServiceMonitor

Image: quay.io/rhn_support_ropatil/portfix@sha256:12e55d3b782d81216aca5b45cab668a6a39776a26de62f06b5b6bd755d2b17fd 

// Verification:
```
oc get pods -n openshift-secondary-scheduler-operator
NAME                                            READY   STATUS    RESTARTS      AGE
secondary-scheduler-86b7c8f5df-25hv7            1/1     Running   0             32m
secondary-scheduler-operator-794896dbbf-xxx6x   1/1     Running   1 (32m ago)   33m

oc get pod -n openshift-secondary-scheduler-operator  -l name=secondary-scheduler-operator \
 -o jsonpath='{.items[0].spec.containers[0].ports}'
[
  {
    "containerPort": 8443,
    "name": "https",
    "protocol": "TCP"
  }
]
```
// Before PR fix:
```
2. $ oc run probe-test --image=busybox --rm -it --restart=Never -- \
    sh -c "wget -qO- --timeout=5 http://10.129.2.22:60000 2>&1"
wget: can't connect to remote host (10.129.2.22): Connection refused
  "Connection refused" (fast/instant) = TCP RST = packet reached the pod but nothing is listening.
```

// After PR fix:
```
oc run probe-test --image=busybox --rm -it --restart=Never -- \
  sh -c "wget -qO- --no-check-certificate --timeout=5 https://${OPERATOR_POD_IP}:8443 2>&1 && echo REACHABLE || echo UNREACHABLE"
All commands and output from this session will be recorded in container logs, including credentials and sensitive information passed through the command prompt.
If you don't see a command prompt, try pressing enter.
warning: couldn't attach to pod/probe-test, falling back to streaming logs: unable to upgrade connection: container probe-test not found in pod probe-test_default
wget: server returned error: HTTP/1.1 403 Forbidden
UNREACHABLE
pod "probe-test" deleted from default namespace

1. TCP connection - succeeded
2. TLS handshake - succeeded
3. HTTP response - 403 Forbidden (auth rejected the anonymous request)
```

Discussion: https://redhat-internal.slack.com/archives/GK58XC2G2/p1787655902401529