### PR TITLE
NO-JIRA: Add RBAC manifests to install-local target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,11 @@ generate-clients:
 install-local:
 	oc apply -f deploy/00_secondary-scheduler-operator.crd.yaml
 	oc apply -f deploy/01_namespace.yaml
+	oc apply -f deploy/02_clusterrole.yaml
+	oc apply -f deploy/03_clusterrolebinding.yaml
+	oc apply -f deploy/03_operatorrole.yaml
+	oc apply -f deploy/04_serviceaccount.yaml
+	oc apply -f deploy/04_operatorrolebinding.yaml
 	oc apply -f deploy/06_configmap.yaml
 	oc apply -f deploy/07_secondary-scheduler-operator.cr.yaml
 


### PR DESCRIPTION
Hi Team,

PTAL on the PR. 

The PR introduces namespace-scoped RBAC for networkpolicies (ClusterRole → Role). Without applying the RBAC manifests during local setup, the service account permissions cannot be verified using `oc auth can-i`.

The operator creates some RBAC resources at runtime, but the ClusterRole, Role, and their bindings must exist on the cluster for RBAC testing. Adding them to install-local is idempotent and has no side effects.

When we install operator from deploy folder it installs all the necessary rbac related things which makes RBAC cases to PASS. But when we try to install operator from makefile make install-local, make run-local it fails bec it did not installed those files. 

Created by operator at runtime
```
- ServiceAccount/secondary-scheduler (operand SA)
- ClusterRoleBinding/secondary-scheduler-system-kube-scheduler (operand)
- ClusterRoleBinding/secondary-scheduler-system-volume-scheduler (operand)
- Role/prometheus-k8s (for Prometheus scraping)
- RoleBinding/prometheus-k8s
- Role/secondary-scheduler-operand (operand role)
- RoleBinding/secondary-scheduler-operand
```
NOT created by operator — missing from logs:
```
- ClusterRole/secondary-scheduler-operator (operator's own ClusterRole)
- Role/secondary-scheduler-operator (operator's own Role — the one with networkpolicies)
- ClusterRoleBinding for the operator SA
- ServiceAccount/secondary-scheduler-operator (operator's own SA)
- RoleBinding for the operator Role
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local installation now applies the required access-control and service-account deployment manifests, enabling more complete setup of the operator environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->