### PR TITLE
NO-JIRA: Refactor the namespace code for the OSSO operator

### DIFF
--- a/bindata/assets/secondary-scheduler/deployment.yaml
+++ b/bindata/assets/secondary-scheduler/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "secondary-scheduler"
-  namespace: "openshift-secondary-scheduler-operator"
+  namespace: ${NAMESPACE}
   labels:
     app: "secondary-scheduler"
 spec:
@@ -51,7 +51,7 @@ spec:
             - --leader-elect-renew-deadline=107s
             - --leader-elect-resource-lock=leases
             - --leader-elect-resource-name=secondary-scheduler
-            - --leader-elect-resource-namespace=openshift-secondary-scheduler-operator
+            - --leader-elect-resource-namespace=${NAMESPACE}
             - --leader-elect-retry-period=26s
           env:
           - name: ENABLE_OPENSHIFT_AUTH

--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -29,6 +29,7 @@ var _ v1helpers.OperatorClient = &SecondarySchedulerClient{}
 
 type SecondarySchedulerClient struct {
 	Ctx            context.Context
+	Namespace      string
 	SharedInformer cache.SharedIndexInformer
 	OperatorClient operatorconfigclientv1.SecondaryschedulersV1Interface
 }
@@ -37,8 +38,12 @@ func (c SecondarySchedulerClient) Informer() cache.SharedIndexInformer {
 	return c.SharedInformer
 }
 
+func (c SecondarySchedulerClient) GetNamespace() string {
+	return c.Namespace
+}
+
 func (c SecondarySchedulerClient) GetOperatorState() (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error) {
-	instance, err := c.OperatorClient.SecondarySchedulers(OperatorNamespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := c.OperatorClient.SecondarySchedulers(c.Namespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -50,7 +55,7 @@ func (c SecondarySchedulerClient) GetOperatorStateWithQuorum(ctx context.Context
 }
 
 func (c *SecondarySchedulerClient) UpdateOperatorSpec(ctx context.Context, resourceVersion string, spec *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error) {
-	original, err := c.OperatorClient.SecondarySchedulers(OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	original, err := c.OperatorClient.SecondarySchedulers(c.Namespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -58,7 +63,7 @@ func (c *SecondarySchedulerClient) UpdateOperatorSpec(ctx context.Context, resou
 	copy.ResourceVersion = resourceVersion
 	copy.Spec.OperatorSpec = *spec
 
-	ret, err := c.OperatorClient.SecondarySchedulers(OperatorNamespace).Update(ctx, copy, v1.UpdateOptions{})
+	ret, err := c.OperatorClient.SecondarySchedulers(c.Namespace).Update(ctx, copy, v1.UpdateOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -67,7 +72,7 @@ func (c *SecondarySchedulerClient) UpdateOperatorSpec(ctx context.Context, resou
 }
 
 func (c *SecondarySchedulerClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, status *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error) {
-	original, err := c.OperatorClient.SecondarySchedulers(OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	original, err := c.OperatorClient.SecondarySchedulers(c.Namespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +80,7 @@ func (c *SecondarySchedulerClient) UpdateOperatorStatus(ctx context.Context, res
 	copy.ResourceVersion = resourceVersion
 	copy.Status.OperatorStatus = *status
 
-	ret, err := c.OperatorClient.SecondarySchedulers(OperatorNamespace).UpdateStatus(ctx, copy, v1.UpdateOptions{})
+	ret, err := c.OperatorClient.SecondarySchedulers(c.Namespace).UpdateStatus(ctx, copy, v1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +88,7 @@ func (c *SecondarySchedulerClient) UpdateOperatorStatus(ctx context.Context, res
 }
 
 func (c *SecondarySchedulerClient) GetObjectMeta() (meta *metav1.ObjectMeta, err error) {
-	instance, err := c.OperatorClient.SecondarySchedulers(OperatorNamespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := c.OperatorClient.SecondarySchedulers(c.Namespace).Get(c.Ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -98,10 +103,10 @@ func (c *SecondarySchedulerClient) ApplyOperatorSpec(ctx context.Context, fieldM
 	desiredSpec := &secondaryschedulerapplyconfiguration.SecondarySchedulerSpecApplyConfiguration{
 		OperatorSpecApplyConfiguration: *desiredConfiguration,
 	}
-	desired := secondaryschedulerapplyconfiguration.SecondaryScheduler(OperatorConfigName, OperatorNamespace)
+	desired := secondaryschedulerapplyconfiguration.SecondaryScheduler(OperatorConfigName, c.Namespace)
 	desired.WithSpec(desiredSpec)
 
-	instance, err := c.OperatorClient.SecondarySchedulers(OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := c.OperatorClient.SecondarySchedulers(c.Namespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
 	// do nothing and proceed with the apply
@@ -117,7 +122,7 @@ func (c *SecondarySchedulerClient) ApplyOperatorSpec(ctx context.Context, fieldM
 		}
 	}
 
-	_, err = c.OperatorClient.SecondarySchedulers(OperatorNamespace).Apply(ctx, desired, v1.ApplyOptions{
+	_, err = c.OperatorClient.SecondarySchedulers(c.Namespace).Apply(ctx, desired, v1.ApplyOptions{
 		Force:        true,
 		FieldManager: fieldManager,
 	})
@@ -136,10 +141,10 @@ func (c *SecondarySchedulerClient) ApplyOperatorStatus(ctx context.Context, fiel
 	desiredStatus := &secondaryschedulerapplyconfiguration.SecondarySchedulerStatusApplyConfiguration{
 		OperatorStatusApplyConfiguration: *desiredConfiguration,
 	}
-	desired := secondaryschedulerapplyconfiguration.SecondaryScheduler(OperatorConfigName, OperatorNamespace)
+	desired := secondaryschedulerapplyconfiguration.SecondaryScheduler(OperatorConfigName, c.Namespace)
 	desired.WithStatus(desiredStatus)
 
-	instance, err := c.OperatorClient.SecondarySchedulers(OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := c.OperatorClient.SecondarySchedulers(c.Namespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
 		// do nothing and proceed with the apply
@@ -161,7 +166,7 @@ func (c *SecondarySchedulerClient) ApplyOperatorStatus(ctx context.Context, fiel
 		}
 	}
 
-	_, err = c.OperatorClient.SecondarySchedulers(OperatorNamespace).ApplyStatus(ctx, desired, v1.ApplyOptions{
+	_, err = c.OperatorClient.SecondarySchedulers(c.Namespace).ApplyStatus(ctx, desired, v1.ApplyOptions{
 		Force:        true,
 		FieldManager: fieldManager,
 	})
@@ -177,6 +182,6 @@ func (c *SecondarySchedulerClient) PatchOperatorStatus(ctx context.Context, json
 	if err != nil {
 		return err
 	}
-	_, err = c.OperatorClient.SecondarySchedulers(OperatorNamespace).Patch(ctx, OperatorConfigName, types.JSONPatchType, jsonPatchBytes, metav1.PatchOptions{}, "/status")
+	_, err = c.OperatorClient.SecondarySchedulers(c.Namespace).Patch(ctx, OperatorConfigName, types.JSONPatchType, jsonPatchBytes, metav1.PatchOptions{}, "/status")
 	return err
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -43,9 +43,13 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 		return err
 	}
 
+	// NOTE: For custom namespace support in future, WATCH_NAMESPACE env should be assigned to operatorNamespace
+	operatorNamespace := operatorclient.OperatorNamespace
+	klog.Infof("Operator running in namespace: %s", operatorNamespace)
+
 	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient,
 		"",
-		operatorclient.OperatorNamespace,
+		operatorNamespace,
 	)
 
 	operatorConfigClient, err := operatorconfigclient.NewForConfig(cc.KubeConfig)
@@ -55,6 +59,7 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	operatorConfigInformers := operatorclientinformers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
 	secondarySchedulerClient := &operatorclient.SecondarySchedulerClient{
 		Ctx:            ctx,
+		Namespace:      operatorNamespace,
 		SharedInformer: operatorConfigInformers.Secondaryschedulers().V1().SecondarySchedulers().Informer(),
 		OperatorClient: operatorConfigClient.SecondaryschedulersV1(),
 	}

--- a/pkg/operator/target_config_reconciler.go
+++ b/pkg/operator/target_config_reconciler.go
@@ -88,7 +88,7 @@ func NewTargetConfigReconciler(
 		return nil, err
 	}
 
-	_, err = kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = kubeInformersForNamespaces.InformersFor(secondarySchedulerClient.GetNamespace()).Core().V1().ConfigMaps().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {},
 		UpdateFunc: func(old, new interface{}) {
 			cm, ok := old.(*v1.ConfigMap)
@@ -122,9 +122,10 @@ func getResourceVersion(obj metav1.Object) string {
 }
 
 func (c TargetConfigReconciler) sync(item queueItem) error {
-	secondaryScheduler, err := c.operatorClient.SecondarySchedulers(operatorclient.OperatorNamespace).Get(c.ctx, operatorclient.OperatorConfigName, metav1.GetOptions{})
+	operatorNamespace := c.secondarySchedulerClient.GetNamespace()
+	secondaryScheduler, err := c.operatorClient.SecondarySchedulers(operatorNamespace).Get(c.ctx, operatorclient.OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
-		klog.ErrorS(err, "unable to get operator configuration", "namespace", operatorclient.OperatorNamespace, "secondary-scheduler", operatorclient.OperatorConfigName)
+		klog.ErrorS(err, "unable to get operator configuration", "namespace", operatorNamespace, "secondary-scheduler", operatorclient.OperatorConfigName)
 		return err
 	}
 
@@ -211,7 +212,8 @@ func (c TargetConfigReconciler) sync(item queueItem) error {
 }
 
 func (c *TargetConfigReconciler) getConfigMapResourceVersion(secondaryScheduler *secondaryschedulersv1.SecondaryScheduler) (string, error) {
-	required, err := c.kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().ConfigMaps().Lister().ConfigMaps(operatorclient.OperatorNamespace).Get(secondaryScheduler.Spec.SchedulerConfig)
+	operatorNamespace := c.secondarySchedulerClient.GetNamespace()
+	required, err := c.kubeInformersForNamespaces.InformersFor(operatorNamespace).Core().V1().ConfigMaps().Lister().ConfigMaps(operatorNamespace).Get(secondaryScheduler.Spec.SchedulerConfig)
 	if err != nil {
 		return "", fmt.Errorf("could not get configuration configmap: %v", err)
 	}
@@ -408,6 +410,17 @@ func (c *TargetConfigReconciler) manageDeployment(secondaryScheduler *secondarys
 				required.Spec.Template.Spec.Volumes[i].ConfigMap.Name = configmap
 				break
 			}
+		}
+	}
+
+	// Replace ${NAMESPACE} placeholder in container args (for leader-elect-resource-namespace)
+	for i := range required.Spec.Template.Spec.Containers {
+		for j := range required.Spec.Template.Spec.Containers[i].Args {
+			required.Spec.Template.Spec.Containers[i].Args[j] = strings.ReplaceAll(
+				required.Spec.Template.Spec.Containers[i].Args[j],
+				"${NAMESPACE}",
+				secondaryScheduler.Namespace,
+			)
 		}
 	}
 

--- a/pkg/operator/target_config_reconciler_test.go
+++ b/pkg/operator/target_config_reconciler_test.go
@@ -177,6 +177,7 @@ func setupFakeClients(t *testing.T, apiServer *configv1.APIServer, secondarySche
 
 	secondarySchedulerClient := &operatorclient.SecondarySchedulerClient{
 		Ctx:            context.TODO(),
+		Namespace:      operatorclient.OperatorNamespace,
 		SharedInformer: operatorConfigInformers.Secondaryschedulers().V1().SecondarySchedulers().Informer(),
 		OperatorClient: fakeOperatorConfigClient.SecondaryschedulersV1(),
 	}


### PR DESCRIPTION
Refactor the namespace code for the OSSO operator

Attached artifacts can be used, if the operator supports custom namespace later
[verify-reconciliation.sh](https://github.com/user-attachments/files/31895155/verify-reconciliation.sh)
[cleanup-test.sh](https://github.com/user-attachments/files/31895152/cleanup-test.sh)
[test-single-namespace.sh](https://github.com/user-attachments/files/31895210/test-single-namespace.sh)
