### PR TITLE
chore(version): update operator version to 1.6.1

### DIFF
--- a/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
+++ b/manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
       ]
     certified: "false"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/secondary-scheduler-rhel9-operator:latest
-    createdAt: "2026-08-16"
+    createdAt: "2026-09-11"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"


### PR DESCRIPTION
This PR updates the operator version to 1.6.1.

Automatically generated by a mintmaker tool.