### PR TITLE
no-jira: feat(CSV): set the createAt date to the image build date

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -9,6 +9,7 @@ ARG OPERATOR_IMAGE=registry.redhat.io/openshift-secondary-scheduler-operator/sec
 ARG REPLACED_OPERATOR_IMG=registry-proxy.engineering.redhat.com/rh-osbs/secondary-scheduler-rhel9-operator:latest
 
 RUN hack/replace-image.sh manifests ${REPLACED_OPERATOR_IMG} ${OPERATOR_IMAGE}
+RUN sed -i "s/createdAt: \".*\"/createdAt: \"$(date -I)\"/" manifests/cluster-secondary-scheduler-operator.clusterserviceversion.yaml
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:d235f607e1d6d833f031db107dc42206e4dd4d5aa9142c43d3771fb7f9bea76a
 


### PR DESCRIPTION
ssia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CSV records now receive the current ISO-formatted creation date when the image is built.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->