### PR TITLE
no-jira: feat(releases): make the column names shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ The Secondary Scheduler Operator provides the ability to deploy a customized sch
 
 ```
 releases:
-- {version: "1.1.0",       ocp_version: "4.11-4.13",  k8s_version: "1.21", golang: "1.18", release_branch: "4.11"}
-- {version: "1.1.2",       ocp_version: "4.12, 4.13", k8s_version: "1.26", golang: "1.19", release_branch: "4.12"}
-- {version: "1.1.3-1.1.6", ocp_version: "4.12, 4.13", k8s_version: "1.26", golang: "1.19", release_branch: "4.13"}
-- {version: "1.2.0",       ocp_version: "4.14, 4.15", k8s_version: "1.27", golang: "1.20", release_branch: "4.14"}
-- {version: "1.2.1-1.2.4", ocp_version: "4.14, 4.15", k8s_version: "1.28", golang: "1.20", release_branch: "4.15"}
-- {version: "1.3.0",       ocp_version: "4.16, 4.17", k8s_version: "1.29", golang: "1.21", release_branch: "4.16"}
-- {version: "1.3.1-1.3.3", ocp_version: "4.16, 4.17", k8s_version: "1.30", golang: "1.22", release_branch: "4.17"}
-- {version: "1.4.0",       ocp_version: "4.18, 4.19", k8s_version: "1.31", golang: "1.22", release_branch: "4.18"}
-- {version: "1.4.1-1.4.3", ocp_version: "4.18, 4.19", k8s_version: "1.32", golang: "1.23", release_branch: "4.19"}
-- {version: "1.5.0",       ocp_version: "4.20, 4.21", k8s_version: "1.33", golang: "1.24", release_branch: "4.20"}
-- {version: "1.5.1-1.5.2", ocp_version: "4.20, 4.21", k8s_version: "1.34", golang: "1.24", release_branch: "4.21"}
-- {version: "1.6.0",       ocp_version: "4.22, 5.0",  k8s_version: "1.35", golang: "1.25", release_branch: "4.22"}
-- {version: "1.6.1",       ocp_version: "4.22, 5.0",  k8s_version: "1.36", golang: "1.26", release_branch: "5.0"}
+- {version: "1.1.0",       ocp: "4.11-4.13",  k8s: "1.21", go: "1.18", release_branch: "4.11"}
+- {version: "1.1.2",       ocp: "4.12, 4.13", k8s: "1.26", go: "1.19", release_branch: "4.12"}
+- {version: "1.1.3-1.1.6", ocp: "4.12, 4.13", k8s: "1.26", go: "1.19", release_branch: "4.13"}
+- {version: "1.2.0",       ocp: "4.14, 4.15", k8s: "1.27", go: "1.20", release_branch: "4.14"}
+- {version: "1.2.1-1.2.4", ocp: "4.14, 4.15", k8s: "1.28", go: "1.20", release_branch: "4.15"}
+- {version: "1.3.0",       ocp: "4.16, 4.17", k8s: "1.29", go: "1.21", release_branch: "4.16"}
+- {version: "1.3.1-1.3.3", ocp: "4.16, 4.17", k8s: "1.30", go: "1.22", release_branch: "4.17"}
+- {version: "1.4.0",       ocp: "4.18, 4.19", k8s: "1.31", go: "1.22", release_branch: "4.18"}
+- {version: "1.4.1-1.4.3", ocp: "4.18, 4.19", k8s: "1.32", go: "1.23", release_branch: "4.19"}
+- {version: "1.5.0",       ocp: "4.20, 4.21", k8s: "1.33", go: "1.24", release_branch: "4.20"}
+- {version: "1.5.1-1.5.2", ocp: "4.20, 4.21", k8s: "1.34", go: "1.24", release_branch: "4.21"}
+- {version: "1.6.0",       ocp: "4.22, 5.0",  k8s: "1.35", go: "1.25", release_branch: "4.22"}
+- {version: "1.6.1",       ocp: "4.22, 5.0",  k8s: "1.36", go: "1.26", release_branch: "5.0"}
 ```
 
 ## Deploy the Operator


### PR DESCRIPTION
ssia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Releases table to use shorter field labels: `ocp`, `k8s`, and `go`.
  - Existing release entries and values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->